### PR TITLE
Revert use of js #private as it breaks the integration with unmigrated code

### DIFF
--- a/src/drawables/Background.ts
+++ b/src/drawables/Background.ts
@@ -8,46 +8,46 @@ import Enums from '../misc/Enums';
 class Background {
 
   /** WebGL Context */
-  #gl;
+  _gl;
   /** Owning scene */
-  #main;
+  _main;
   /** VertexBuffer */
-  #vertexBuffer;
+  _vertexBuffer;
   /** Texture coordinates buffer */
-  #texCoordBuffer;
+  _texCoordBuffer;
   /** Should canvas be filled by background @type {boolean} */
-  #fill;
+  _fill;
   /** One pixel texture used as background if no other is supplied */
-  #monoTex;
+  _monoTex;
   /** Background texture ( if one is provided ) */
-  #texture;
+  _texture;
   /** Height of the texture */
-  #texWidth;
+  _texWidth;
   /** Width of the texture */
-  #texHeight;
+  _texHeight;
   /** Texture type,  0: fixed grey, 1 env spec, 2 env ambient */
-  #type;
+  _type;
   /** Should the texture be blurred @type {boolean} */
-  #blur;
+  _blur;
 
   constructor(gl, main) {
-    this.#gl = gl;
-    this.#main = main;
-    this.#vertexBuffer = new Buffer(gl, gl.ARRAY_BUFFER, gl.STATIC_DRAW);
-    this.#texCoordBuffer = new Buffer(gl, gl.ARRAY_BUFFER, gl.STATIC_DRAW);
-    this.#fill = true;
-    this.#monoTex = null;
-    this.#texture = null;
-    this.#texWidth = 1;
-    this.#texHeight = 1;
-    this.#type = 0;
-    this.#blur = 0.0;
+    this._gl = gl;
+    this._main = main;
+    this._vertexBuffer = new Buffer(gl, gl.ARRAY_BUFFER, gl.STATIC_DRAW);
+    this._texCoordBuffer = new Buffer(gl, gl.ARRAY_BUFFER, gl.STATIC_DRAW);
+    this._fill = true;
+    this._monoTex = null;
+    this._texture = null;
+    this._texWidth = 1;
+    this._texHeight = 1;
+    this._type = 0;
+    this._blur = 0.0;
     this.init();
   }
 
   init() {
-    this.#texCoordBuffer.update(new Float32Array([0.0, 0.0, 1.0, 0.0, 0.0, 1.0, 1.0, 1.0]));
-    this.#monoTex = this.createOnePixelTexture(50, 50, 50, 255);
+    this._texCoordBuffer.update(new Float32Array([0.0, 0.0, 1.0, 0.0, 0.0, 1.0, 1.0, 1.0]));
+    this._monoTex = this.createOnePixelTexture(50, 50, 50, 255);
     let element = document
       .getElementById('backgroundopen');
     if (element != null) {
@@ -76,7 +76,7 @@ class Background {
       }
       bg.onload = function () {
 
-        var canvas = self.#main.getCanvas();
+        var canvas = self._main.getCanvas();
         self.loadBackgroundTexture(bg);
         self.onResize(canvas.width, canvas.height);
         self.main.render();
@@ -91,53 +91,53 @@ class Background {
   }
 
   get gl() {
-    return this.#gl;
+    return this._gl;
   }
 
   get main() {
-    return this.#main;
+    return this._main;
   }
 
   get blur() {
-    return this.#blur;
+    return this._blur;
   }
 
   get vertexBuffer() {
-    return this.#vertexBuffer;
+    return this._vertexBuffer;
   }
 
   get texCoordBuffer() {
-    return this.#texCoordBuffer;
+    return this._texCoordBuffer;
   }
 
   release() {
     this.deleteTexture();
-    this.#vertexBuffer().release();
-    this.#texCoordBuffer().release();
+    this._vertexBuffer().release();
+    this._texCoordBuffer().release();
   }
 
   get type() {
-    return this.#type;
+    return this._type;
   }
 
   set type(val) {
-    this.#type = val;
+    this._type = val;
   }
 
   onResize(width, height) {
-    var ratio = (width / height) / (this.#texWidth / this.#texHeight);
-    var comp = this.#fill || this.#type !== 0 ? 1.0 / ratio : ratio;
+    var ratio = (width / height) / (this._texWidth / this._texHeight);
+    var comp = this._fill || this._type !== 0 ? 1.0 / ratio : ratio;
     var x = comp < 1.0 ? 1.0 : 1.0 / ratio;
     var y = comp < 1.0 ? ratio : 1.0;
-    this.#vertexBuffer.update(new Float32Array([-x, -y, x, -y, -x, y, x, y]));
+    this._vertexBuffer.update(new Float32Array([-x, -y, x, -y, -x, y, x, y]));
   }
 
   getTexture() {
-    return this.#texture ? this.#texture : this.#monoTex;
+    return this._texture ? this._texture : this._monoTex;
   }
 
   createOnePixelTexture(r, g, b, a) {
-    var gl = this.#gl;
+    var gl = this._gl;
     var tex = gl.createTexture();
     gl.bindTexture(gl.TEXTURE_2D, tex);
     gl.texImage2D(
@@ -158,14 +158,14 @@ class Background {
   }
 
   loadBackgroundTexture(tex) {
-    var gl = this.#gl;
+    var gl = this._gl;
     this.deleteTexture();
 
-    this.#texWidth = tex.width;
-    this.#texHeight = tex.height;
-    this.#texture = gl.createTexture();
+    this._texWidth = tex.width;
+    this._texHeight = tex.height;
+    this._texture = gl.createTexture();
 
-    gl.bindTexture(gl.TEXTURE_2D, this.#texture);
+    gl.bindTexture(gl.TEXTURE_2D, this._texture);
     gl.texImage2D(gl.TEXTURE_2D, 0, gl.RGBA, gl.RGBA, gl.UNSIGNED_BYTE, tex);
     gl.texParameteri(gl.TEXTURE_2D, gl.TEXTURE_MIN_FILTER, gl.LINEAR);
     gl.texParameteri(gl.TEXTURE_2D, gl.TEXTURE_WRAP_S, gl.CLAMP_TO_EDGE);
@@ -174,15 +174,15 @@ class Background {
   }
 
   deleteTexture() {
-    if (this.#texture) {
-      this.#texWidth = this.#texHeight = 1;
-      this.#gl.deleteTexture(this.#texture);
-      this.#texture = null;
+    if (this._texture) {
+      this._texWidth = this._texHeight = 1;
+      this._gl.deleteTexture(this._texture);
+      this._texture = null;
     }
   }
 
   render() {
-    Shader[Enums.Shader.BACKGROUND].getOrCreate(this.#gl).draw(this);
+    Shader[Enums.Shader.BACKGROUND].getOrCreate(this._gl).draw(this);
   }
 }
 

--- a/src/drawables/Rtt.ts
+++ b/src/drawables/Rtt.ts
@@ -9,31 +9,31 @@ var singletonBuffer;
  */
 class Rtt {
 
-  #gl;
-  #texture;
-  #depth;
-  #framebuffer;
-  #shaderType;
-  inverseSize; 
-  #vertexBuffer; 
-  #type;
-  #wrapRepeat;
-  #filterNearest;
+  _gl;
+  _texture;
+  _depth;
+  _framebuffer;
+  _shaderType;
+  inverseSize;
+  _vertexBuffer;
+  _type;
+  _wrapRepeat;
+  _filterNearest;
 
   constructor(gl, shaderName = null, depth = gl.createRenderbuffer(), halfFloat = false) {
-    this.#gl = gl; // webgl context
+    this._gl = gl; // webgl context
 
-    this.#texture = gl.createTexture();
-    this.#depth = depth;
-    this.#framebuffer = gl.createFramebuffer();
+    this._texture = gl.createTexture();
+    this._depth = depth;
+    this._framebuffer = gl.createFramebuffer();
 
-    this.#shaderType = shaderName;
+    this._shaderType = shaderName;
     this.inverseSize = new Float32Array(2);
-    this.#vertexBuffer = null;
+    this._vertexBuffer = null;
 
-    if (halfFloat && WebGLCaps.hasRTTHalfFloat()) this.#type = WebGLCaps.HALF_FLOAT_OES;
-    else if (halfFloat && WebGLCaps.hasRTTFloat()) this.#type = gl.FLOAT;
-    else this.#type = gl.UNSIGNED_BYTE;
+    if (halfFloat && WebGLCaps.hasRTTHalfFloat()) this._type = WebGLCaps.HALF_FLOAT_OES;
+    else if (halfFloat && WebGLCaps.hasRTTFloat()) this._type = gl.FLOAT;
+    else this._type = gl.UNSIGNED_BYTE;
 
     this.setWrapRepeat(false);
     this.setFilterNearest(false);
@@ -41,23 +41,23 @@ class Rtt {
   }
 
   getGL() {
-    return this.#gl;
+    return this._gl;
   }
 
   getVertexBuffer() {
-    return this.#vertexBuffer;
+    return this._vertexBuffer;
   }
 
   getFramebuffer() {
-    return this.#framebuffer;
+    return this._framebuffer;
   }
 
   getTexture() {
-    return this.#texture;
+    return this._texture;
   }
 
   getDepth() {
-    return this.#depth;
+    return this._depth;
   }
 
   getInverseSize() {
@@ -65,62 +65,62 @@ class Rtt {
   }
 
   init() {
-    var gl = this.#gl;
+    var gl = this._gl;
 
     if (!singletonBuffer) {
       singletonBuffer = new Buffer(gl, gl.ARRAY_BUFFER, gl.STATIC_DRAW);
       singletonBuffer.update(new Float32Array([-1.0, -1.0, 4.0, -1.0, -1.0, 4.0]));
     }
 
-    this.#vertexBuffer = singletonBuffer;
+    this._vertexBuffer = singletonBuffer;
   }
 
   setWrapRepeat(bool) {
-    this.#wrapRepeat = bool;
+    this._wrapRepeat = bool;
   }
 
   setFilterNearest(bool) {
-    this.#filterNearest = bool;
+    this._filterNearest = bool;
   }
 
   onResize(width, height) {
-    var gl = this.#gl;
+    var gl = this._gl;
 
     this.inverseSize[0] = 1.0 / width;
     this.inverseSize[1] = 1.0 / height;
 
-    gl.bindTexture(gl.TEXTURE_2D, this.#texture);
-    gl.texImage2D(gl.TEXTURE_2D, 0, gl.RGBA, width, height, 0, gl.RGBA, this.#type, null);
+    gl.bindTexture(gl.TEXTURE_2D, this._texture);
+    gl.texImage2D(gl.TEXTURE_2D, 0, gl.RGBA, width, height, 0, gl.RGBA, this._type, null);
 
-    var filter = this.#filterNearest ? gl.NEAREST : gl.LINEAR;
+    var filter = this._filterNearest ? gl.NEAREST : gl.LINEAR;
     gl.texParameteri(gl.TEXTURE_2D, gl.TEXTURE_MAG_FILTER, filter);
     gl.texParameteri(gl.TEXTURE_2D, gl.TEXTURE_MIN_FILTER, filter);
 
-    var wrap = this.#wrapRepeat ? gl.REPEAT : gl.CLAMP_TO_EDGE;
+    var wrap = this._wrapRepeat ? gl.REPEAT : gl.CLAMP_TO_EDGE;
     gl.texParameteri(gl.TEXTURE_2D, gl.TEXTURE_WRAP_S, wrap);
     gl.texParameteri(gl.TEXTURE_2D, gl.TEXTURE_WRAP_T, wrap);
 
-    if (this.#depth) {
-      gl.bindRenderbuffer(gl.RENDERBUFFER, this.#depth);
+    if (this._depth) {
+      gl.bindRenderbuffer(gl.RENDERBUFFER, this._depth);
       gl.renderbufferStorage(gl.RENDERBUFFER, gl.DEPTH_STENCIL, width, height);
     }
 
-    gl.bindFramebuffer(gl.FRAMEBUFFER, this.#framebuffer);
-    gl.framebufferTexture2D(gl.FRAMEBUFFER, gl.COLOR_ATTACHMENT0, gl.TEXTURE_2D, this.#texture, 0);
+    gl.bindFramebuffer(gl.FRAMEBUFFER, this._framebuffer);
+    gl.framebufferTexture2D(gl.FRAMEBUFFER, gl.COLOR_ATTACHMENT0, gl.TEXTURE_2D, this._texture, 0);
     gl.framebufferRenderbuffer(
-      gl.FRAMEBUFFER, gl.DEPTH_STENCIL_ATTACHMENT, gl.RENDERBUFFER, this.#depth
+      gl.FRAMEBUFFER, gl.DEPTH_STENCIL_ATTACHMENT, gl.RENDERBUFFER, this._depth
     );
 
     gl.bindTexture(gl.TEXTURE_2D, null);
   }
 
   release() {
-    if (this.#texture) this.#gl.deleteTexture(this.#texture);
+    if (this._texture) this._gl.deleteTexture(this._texture);
     this.getVertexBuffer().release();
   }
 
   render(main) {
-    Shader[this.#shaderType].getOrCreate(this.#gl).draw(this, main);
+    Shader[this._shaderType].getOrCreate(this._gl).draw(this, main);
   }
 }
 

--- a/src/drawables/Selection.ts
+++ b/src/drawables/Selection.ts
@@ -8,86 +8,86 @@ import Enums from '../misc/Enums';
 /** Handles rendering the selection tool */
 class Selection {
 
-  #gl;
+  _gl;
 
-  #circleBuffer;
-  #dotBuffer;
+  _circleBuffer;
+  _dotBuffer;
 
-  #cacheDotMVP = mat4.create();
-  #cacheDotSymMVP = mat4.create();
-  #cacheCircleMVP = mat4.create();
-  #color = new Float32Array([0.8, 0.0, 0.0]);
+  _cacheDotMVP = mat4.create();
+  _cacheDotSymMVP = mat4.create();
+  _cacheCircleMVP = mat4.create();
+  _color = new Float32Array([0.8, 0.0, 0.0]);
 
   // TODO: These are scratch variables and the names should be fixed up
-  #tmp_matpv = mat4.create();
-  #tmp_mat = mat4.create();
-  #tmp_mat3 = mat3.create();
-  #tmp_vec = new Float32Array([0.0, 0.0, 0.0]);
-  #tmp_axis = new Float32Array([0.0, 0.0, 0.0]);
-  #base = new Float32Array([0.0, 0.0, 1.0]);
+  _tmp_matpv = mat4.create();
+  _tmp_mat = mat4.create();
+  _tmp_mat3 = mat3.create();
+  _tmp_vec = new Float32Array([0.0, 0.0, 0.0]);
+  _tmp_axis = new Float32Array([0.0, 0.0, 0.0]);
+  _base = new Float32Array([0.0, 0.0, 1.0]);
 
-  #dot_radius = 50.0;
+  _dot_radius = 50.0;
 
   /** horizontal offset (when editing the radius) */
-  #offsetX = 0.0;
-  #isEditMode = false;
+  _offsetX = 0.0;
+  _isEditMode = false;
 
   constructor(gl) {
-    this.#gl = gl;
+    this._gl = gl;
 
-    this.#circleBuffer = new Buffer(gl, gl.ARRAY_BUFFER, gl.STATIC_DRAW);
-    this.#dotBuffer = new Buffer(gl, gl.ARRAY_BUFFER, gl.STATIC_DRAW);
+    this._circleBuffer = new Buffer(gl, gl.ARRAY_BUFFER, gl.STATIC_DRAW);
+    this._dotBuffer = new Buffer(gl, gl.ARRAY_BUFFER, gl.STATIC_DRAW);
 
     this.init();
   }
 
   getGL() {
-    return this.#gl;
+    return this._gl;
   }
 
   getCircleBuffer() {
-    return this.#circleBuffer;
+    return this._circleBuffer;
   }
 
   getDotBuffer() {
-    return this.#dotBuffer;
+    return this._dotBuffer;
   }
 
   getCircleMVP() {
-    return this.#cacheCircleMVP;
+    return this._cacheCircleMVP;
   }
 
   getDotMVP() {
-    return this.#cacheDotMVP;
+    return this._cacheDotMVP;
   }
 
   getDotSymmetryMVP() {
-    return this.#cacheDotSymMVP;
+    return this._cacheDotSymMVP;
   }
 
   getColor() {
-    return this.#color;
+    return this._color;
   }
 
   setIsEditMode(bool) {
-    this.#isEditMode = bool;
+    this._isEditMode = bool;
   }
 
   getIsEditMode() {
-    return this.#isEditMode;
+    return this._isEditMode;
   }
 
   setOffsetX(offset) {
-    this.#offsetX = offset;
+    this._offsetX = offset;
   }
 
   getOffsetX() {
-    return this.#offsetX;
+    return this._offsetX;
   }
 
   init() {
-    this.getCircleBuffer().update(this.#getCircleVertices(1.0));
-    this.getDotBuffer().update(this.#getDotVertices(0.05, 10));
+    this.getCircleBuffer().update(this._getCircleVertices(1.0));
+    this.getDotBuffer().update(this._getDotVertices(0.05, 10));
   }
 
   release() {
@@ -95,7 +95,7 @@ class Selection {
     this.getDotBuffer().release();
   }
 
-  #getCircleVertices(radius = 1.0, nbVertices = 50, full = false) {
+  _getCircleVertices(radius = 1.0, nbVertices = 50, full = false) {
     var arc = Math.PI * 2;
 
     var start = full ? 1 : 0;
@@ -110,113 +110,113 @@ class Selection {
     return vertices;
   }
 
-  #getDotVertices(r, nb) {
-    return this.#getCircleVertices(r, nb, true);
+  _getDotVertices(r, nb) {
+    return this._getCircleVertices(r, nb, true);
   }
 
-  #updateMatricesBackground(camera, main) {
+  _updateMatricesBackground(camera, main) {
 
     var screenRadius = main.getSculptManager().getCurrentTool().getScreenRadius();
 
     var w = camera._width * 0.5;
     var h = camera._height * 0.5;
     // no need to recompute the ortho proj each time though
-    mat4.ortho(this.#tmp_matpv, -w, w, -h, h, -10.0, 10.0);
+    mat4.ortho(this._tmp_matpv, -w, w, -h, h, -10.0, 10.0);
 
-    mat4.identity(this.#tmp_mat);
+    mat4.identity(this._tmp_mat);
     mat4.translate(
-      this.#tmp_mat,
-      this.#tmp_mat,
-      vec3.set(this.#tmp_vec, -w + main._mouseX + this.#offsetX, h - main._mouseY, 0.0)
+      this._tmp_mat,
+      this._tmp_mat,
+      vec3.set(this._tmp_vec, -w + main._mouseX + this._offsetX, h - main._mouseY, 0.0)
     );
     // circle mvp
     mat4.scale(
-      this.#cacheCircleMVP,
-      this.#tmp_mat,
-      vec3.set(this.#tmp_vec, screenRadius, screenRadius, screenRadius)
+      this._cacheCircleMVP,
+      this._tmp_mat,
+      vec3.set(this._tmp_vec, screenRadius, screenRadius, screenRadius)
     );
-    mat4.mul(this.#cacheCircleMVP, this.#tmp_matpv, this.#cacheCircleMVP);
+    mat4.mul(this._cacheCircleMVP, this._tmp_matpv, this._cacheCircleMVP);
     // dot mvp
     mat4.scale(
-      this.#cacheDotMVP,
-      this.#tmp_mat,
-      vec3.set(this.#tmp_vec, this.#dot_radius, this.#dot_radius, this.#dot_radius)
+      this._cacheDotMVP,
+      this._tmp_mat,
+      vec3.set(this._tmp_vec, this._dot_radius, this._dot_radius, this._dot_radius)
     );
-    mat4.mul(this.#cacheDotMVP, this.#tmp_matpv, this.#cacheDotMVP);
+    mat4.mul(this._cacheDotMVP, this._tmp_matpv, this._cacheDotMVP);
     // symmetry mvp
-    mat4.scale(this.#cacheDotSymMVP, this.#cacheDotSymMVP, [0.0, 0.0, 0.0]);
+    mat4.scale(this._cacheDotSymMVP, this._cacheDotSymMVP, [0.0, 0.0, 0.0]);
   }
 
-  #updateMatricesMesh(camera, main) {
+  _updateMatricesMesh(camera, main) {
     var picking = main.getPicking();
     var pickingSym = main.getPickingSymmetry();
     var worldRadius = Math.sqrt(picking.computeWorldRadius2(true));
     var screenRadius = main.getSculptManager().getCurrentTool().getScreenRadius();
 
     var mesh = picking.getMesh();
-    var constRadius = this.#dot_radius * (worldRadius / screenRadius);
+    var constRadius = this._dot_radius * (worldRadius / screenRadius);
 
-    picking.polyLerp(mesh.getNormals(), this.#tmp_axis);
+    picking.polyLerp(mesh.getNormals(), this._tmp_axis);
     vec3.transformMat3(
-      this.#tmp_axis,
-      this.#tmp_axis,
-      mat3.normalFromMat4(this.#tmp_mat3, mesh.getMatrix())
+      this._tmp_axis,
+      this._tmp_axis,
+      mat3.normalFromMat4(this._tmp_mat3, mesh.getMatrix())
     );
-    vec3.normalize(this.#tmp_axis, this.#tmp_axis);
-    var rad = Math.acos(vec3.dot(this.#base, this.#tmp_axis));
-    vec3.cross(this.#tmp_axis, this.#base, this.#tmp_axis);
+    vec3.normalize(this._tmp_axis, this._tmp_axis);
+    var rad = Math.acos(vec3.dot(this._base, this._tmp_axis));
+    vec3.cross(this._tmp_axis, this._base, this._tmp_axis);
 
-    mat4.identity(this.#tmp_mat);
+    mat4.identity(this._tmp_mat);
     mat4.translate(
-      this.#tmp_mat,
-      this.#tmp_mat,
-      vec3.transformMat4(this.#tmp_vec, picking.getIntersectionPoint(), mesh.getMatrix())
+      this._tmp_mat,
+      this._tmp_mat,
+      vec3.transformMat4(this._tmp_vec, picking.getIntersectionPoint(), mesh.getMatrix())
     );
-    mat4.rotate(this.#tmp_mat, this.#tmp_mat, rad, this.#tmp_axis);
+    mat4.rotate(this._tmp_mat, this._tmp_mat, rad, this._tmp_axis);
 
-    mat4.mul(this.#tmp_matpv, camera.getProjection(), camera.getView());
+    mat4.mul(this._tmp_matpv, camera.getProjection(), camera.getView());
 
     // circle mvp
     mat4.scale(
-      this.#cacheCircleMVP,
-      this.#tmp_mat,
-      vec3.set(this.#tmp_vec, worldRadius, worldRadius, worldRadius)
+      this._cacheCircleMVP,
+      this._tmp_mat,
+      vec3.set(this._tmp_vec, worldRadius, worldRadius, worldRadius)
     );
-    mat4.mul(this.#cacheCircleMVP, this.#tmp_matpv, this.#cacheCircleMVP);
+    mat4.mul(this._cacheCircleMVP, this._tmp_matpv, this._cacheCircleMVP);
     // dot mvp
     mat4.scale(
-      this.#cacheDotMVP,
-      this.#tmp_mat,
-      vec3.set(this.#tmp_vec, constRadius, constRadius, constRadius)
+      this._cacheDotMVP,
+      this._tmp_mat,
+      vec3.set(this._tmp_vec, constRadius, constRadius, constRadius)
     );
-    mat4.mul(this.#cacheDotMVP, this.#tmp_matpv, this.#cacheDotMVP);
+    mat4.mul(this._cacheDotMVP, this._tmp_matpv, this._cacheDotMVP);
     // symmetry mvp
-    vec3.transformMat4(this.#tmp_vec, pickingSym.getIntersectionPoint(), mesh.getMatrix());
-    mat4.identity(this.#tmp_mat);
-    mat4.translate(this.#tmp_mat, this.#tmp_mat, this.#tmp_vec);
-    mat4.rotate(this.#tmp_mat, this.#tmp_mat, rad, this.#tmp_axis);
+    vec3.transformMat4(this._tmp_vec, pickingSym.getIntersectionPoint(), mesh.getMatrix());
+    mat4.identity(this._tmp_mat);
+    mat4.translate(this._tmp_mat, this._tmp_mat, this._tmp_vec);
+    mat4.rotate(this._tmp_mat, this._tmp_mat, rad, this._tmp_axis);
 
     mat4.scale(
-      this.#tmp_mat,
-      this.#tmp_mat,
-      vec3.set(this.#tmp_vec, constRadius, constRadius, constRadius)
+      this._tmp_mat,
+      this._tmp_mat,
+      vec3.set(this._tmp_vec, constRadius, constRadius, constRadius)
     );
-    mat4.mul(this.#cacheDotSymMVP, this.#tmp_matpv, this.#tmp_mat);
+    mat4.mul(this._cacheDotSymMVP, this._tmp_matpv, this._tmp_mat);
   }
 
   render(main) {
     // if there's an offset then it means we are editing the tool radius
-    var pickedMesh = main.getPicking().getMesh() && !this.#isEditMode;
-    if (pickedMesh) this.#updateMatricesMesh(main.getCamera(), main);
-    else this.#updateMatricesBackground(main.getCamera(), main);
+    var pickedMesh = main.getPicking().getMesh() && !this._isEditMode;
+    if (pickedMesh) this._updateMatricesMesh(main.getCamera(), main);
+    else this._updateMatricesBackground(main.getCamera(), main);
 
     var drawCircle = main._action === Enums.Action.NOTHING;
-    vec3.set(this.#color, 0.8, drawCircle && pickedMesh ? 0.0 : 0.4, 0.0);
+    vec3.set(this._color, 0.8, drawCircle && pickedMesh ? 0.0 : 0.4, 0.0);
     ShaderLib[Enums.Shader.SELECTION]
-      .getOrCreate(this.#gl)
+      .getOrCreate(this._gl)
       .draw(this, drawCircle, main.getSculptManager().getSymmetry());
 
-    this.#isEditMode = false;
+    this._isEditMode = false;
   }
 }
 

--- a/src/editing/Gizmo.ts
+++ b/src/editing/Gizmo.ts
@@ -137,117 +137,117 @@ class Gizmo {
     return SCALE_XYZW;
   }
 
-  #main;
-  #gl;
-  #lineHelper;
+  _main;
+  _gl;
+  _lineHelper;
 
   // activated gizmos
-  #activatedType =
+  _activatedType =
     Gizmo.TRANS_XYZ | Gizmo.ROT_XYZ | Gizmo.PLANE_XYZ | Gizmo.SCALE_XYZW | Gizmo.ROT_W;
 
   // trans arrow 1 dim
-  #transX = new GizmoBehavior(Gizmo.TRANS_X, 0);
-  #transY = new GizmoBehavior(Gizmo.TRANS_Y, 1);
-  #transZ = new GizmoBehavior(Gizmo.TRANS_Z, 2);
+  _transX = new GizmoBehavior(Gizmo.TRANS_X, 0);
+  _transY = new GizmoBehavior(Gizmo.TRANS_Y, 1);
+  _transZ = new GizmoBehavior(Gizmo.TRANS_Z, 2);
 
   // trans plane 2 dim
-  #planeX = new GizmoBehavior(Gizmo.PLANE_X, 0);
-  #planeY = new GizmoBehavior(Gizmo.PLANE_Y, 1);
-  #planeZ = new GizmoBehavior(Gizmo.PLANE_Z, 2);
+  _planeX = new GizmoBehavior(Gizmo.PLANE_X, 0);
+  _planeY = new GizmoBehavior(Gizmo.PLANE_Y, 1);
+  _planeZ = new GizmoBehavior(Gizmo.PLANE_Z, 2);
 
   // scale cube 1 dim
-  #scaleX = new GizmoBehavior(Gizmo.SCALE_X, 0);
-  #scaleY = new GizmoBehavior(Gizmo.SCALE_Y, 1);
-  #scaleZ = new GizmoBehavior(Gizmo.SCALE_Z, 2);
+  _scaleX = new GizmoBehavior(Gizmo.SCALE_X, 0);
+  _scaleY = new GizmoBehavior(Gizmo.SCALE_Y, 1);
+  _scaleZ = new GizmoBehavior(Gizmo.SCALE_Z, 2);
   // scale cube 3 dim
-  #scaleW = new GizmoBehavior(Gizmo.SCALE_W);
+  _scaleW = new GizmoBehavior(Gizmo.SCALE_W);
 
   // rot arc 1 dim
-  #rotX = new GizmoBehavior(Gizmo.ROT_X, 0);
-  #rotY = new GizmoBehavior(Gizmo.ROT_Y, 1);
-  #rotZ = new GizmoBehavior(Gizmo.ROT_Z, 2);
+  _rotX = new GizmoBehavior(Gizmo.ROT_X, 0);
+  _rotY = new GizmoBehavior(Gizmo.ROT_Y, 1);
+  _rotZ = new GizmoBehavior(Gizmo.ROT_Z, 2);
   // full arc display
-  #rotW = new GizmoBehavior(Gizmo.ROT_W);
+  _rotW = new GizmoBehavior(Gizmo.ROT_W);
 
 
 
-  #lastDistToEye = 0.0;
-  #isEditing = false;
+  _lastDistToEye = 0.0;
+  _isEditing = false;
 
-  #selected: GizmoBehavior | null = null;
-  #pickables = [];
+  _selected: GizmoBehavior | null = null;
+  _pickables = [];
 
   // editing lines stuffs
-  #editLineOrigin: vec3 = [0.0, 0.0, 0.0];
-  #editLineDirection: vec3 = [0.0, 0.0, 0.0];
-  #editOffset: vec3 = [0.0, 0.0, 0.0];
+  _editLineOrigin: vec3 = [0.0, 0.0, 0.0];
+  _editLineDirection: vec3 = [0.0, 0.0, 0.0];
+  _editOffset: vec3 = [0.0, 0.0, 0.0];
 
   // cached matrices when starting the editing operations
-  #editLocal: mat4[] = [];
-  #editTrans = mat4.create();
-  #editScaleRot: mat4[] = [];
+  _editLocal: mat4[] = [];
+  _editTrans = mat4.create();
+  _editScaleRot: mat4[] = [];
   // same for inv
-  #editLocalInv: mat4[] = [];
-  #editTransInv = mat4.create();
-  #editScaleRotInv: mat4[] = [];
+  _editLocalInv: mat4[] = [];
+  _editTransInv = mat4.create();
+  _editScaleRotInv: mat4[] = [];
 
   constructor(main) {
-    this.#main = main;
-    this.#gl = main._gl;
+    this._main = main;
+    this._gl = main._gl;
 
     // line helper
-    this.#lineHelper = Primitives.createLine2D(this.#gl);
-    this.#lineHelper.setShaderType(Enums.Shader.FLAT);
+    this._lineHelper = Primitives.createLine2D(this._gl);
+    this._lineHelper.setShaderType(Enums.Shader.FLAT);
 
-    this.#initTranslate();
-    this.#initRotate();
-    this.#initScale();
-    this.#initPickables();
+    this._initTranslate();
+    this._initRotate();
+    this._initScale();
+    this._initPickables();
   }
 
   setActivatedType(type) {
-    this.#activatedType = type;
-    this.#initPickables();
+    this._activatedType = type;
+    this._initPickables();
   }
 
-  #initPickables() {
-    var pickables: any[] = this.#pickables;
+  _initPickables() {
+    var pickables: any[] = this._pickables;
     pickables.length = 0;
-    var type = this.#activatedType;
+    var type = this._activatedType;
 
-    if (type & TRANS_X) pickables.push(this.#transX._pickGeo);
-    if (type & TRANS_Y) pickables.push(this.#transY._pickGeo);
-    if (type & TRANS_Z) pickables.push(this.#transZ._pickGeo);
+    if (type & TRANS_X) pickables.push(this._transX._pickGeo);
+    if (type & TRANS_Y) pickables.push(this._transY._pickGeo);
+    if (type & TRANS_Z) pickables.push(this._transZ._pickGeo);
 
-    if (type & PLANE_X) pickables.push(this.#planeX._pickGeo);
-    if (type & PLANE_Y) pickables.push(this.#planeY._pickGeo);
-    if (type & PLANE_Z) pickables.push(this.#planeZ._pickGeo);
+    if (type & PLANE_X) pickables.push(this._planeX._pickGeo);
+    if (type & PLANE_Y) pickables.push(this._planeY._pickGeo);
+    if (type & PLANE_Z) pickables.push(this._planeZ._pickGeo);
 
-    if (type & ROT_X) pickables.push(this.#rotX._pickGeo);
-    if (type & ROT_Y) pickables.push(this.#rotY._pickGeo);
-    if (type & ROT_Z) pickables.push(this.#rotZ._pickGeo);
+    if (type & ROT_X) pickables.push(this._rotX._pickGeo);
+    if (type & ROT_Y) pickables.push(this._rotY._pickGeo);
+    if (type & ROT_Z) pickables.push(this._rotZ._pickGeo);
 
-    if (type & SCALE_X) pickables.push(this.#scaleX._pickGeo);
-    if (type & SCALE_Y) pickables.push(this.#scaleY._pickGeo);
-    if (type & SCALE_Z) pickables.push(this.#scaleZ._pickGeo);
-    if (type & SCALE_W) pickables.push(this.#scaleW._pickGeo);
+    if (type & SCALE_X) pickables.push(this._scaleX._pickGeo);
+    if (type & SCALE_Y) pickables.push(this._scaleY._pickGeo);
+    if (type & SCALE_Z) pickables.push(this._scaleZ._pickGeo);
+    if (type & SCALE_W) pickables.push(this._scaleW._pickGeo);
   }
 
-  #createArrow(tra, axis, color) {
+  _createArrow(tra, axis, color) {
     var mat = tra._baseMatrix;
     mat4.rotate(mat, mat, Math.PI * 0.5, axis);
     mat4.translate(mat, mat, [0.0, ARROW_LENGTH * 0.5, 0.0]);
     vec3.copy(tra._color, color);
 
     tra._pickGeo = Primitives.createArrow(
-      this.#gl,
+      this._gl,
       THICKNESS_PICK,
       ARROW_LENGTH,
       ARROW_CONE_THICK * 0.4
     );
     tra._pickGeo._gizmo = tra;
     tra._drawGeo = Primitives.createArrow(
-      this.#gl,
+      this._gl,
       THICKNESS,
       ARROW_LENGTH,
       ARROW_CONE_THICK,
@@ -256,31 +256,31 @@ class Gizmo {
     tra._drawGeo.setShaderType(Enums.Shader.FLAT);
   }
 
-  #createPlane(pla, color, wx, wy, wz, hx, hy, hz) {
+  _createPlane(pla, color, wx, wy, wz, hx, hy, hz) {
     vec3.copy(pla._color, color);
 
-    pla._pickGeo = Primitives.createPlane(this.#gl, 0.0, 0.0, 0.0, wx, wy, wz, hx, hy, hz);
+    pla._pickGeo = Primitives.createPlane(this._gl, 0.0, 0.0, 0.0, wx, wy, wz, hx, hy, hz);
     pla._pickGeo._gizmo = pla;
-    pla._drawGeo = Primitives.createPlane(this.#gl, 0.0, 0.0, 0.0, wx, wy, wz, hx, hy, hz);
+    pla._drawGeo = Primitives.createPlane(this._gl, 0.0, 0.0, 0.0, wx, wy, wz, hx, hy, hz);
     pla._drawGeo.setShaderType(Enums.Shader.FLAT);
   }
 
-  #initTranslate() {
+  _initTranslate() {
     var axis: vec3 = [0.0, 0.0, 0.0];
-    this.#createArrow(this.#transX, vec3.set(axis, 0.0, 0.0, -1.0), COLOR_X);
-    this.#createArrow(this.#transY, vec3.set(axis, 0.0, 1.0, 0.0), COLOR_Y);
-    this.#createArrow(this.#transZ, vec3.set(axis, 1.0, 0.0, 0.0), COLOR_Z);
+    this._createArrow(this._transX, vec3.set(axis, 0.0, 0.0, -1.0), COLOR_X);
+    this._createArrow(this._transY, vec3.set(axis, 0.0, 1.0, 0.0), COLOR_Y);
+    this._createArrow(this._transZ, vec3.set(axis, 1.0, 0.0, 0.0), COLOR_Z);
 
     var s = ARROW_LENGTH * 0.2;
-    this.#createPlane(this.#planeX, COLOR_X, 0.0, s, 0.0, 0.0, 0.0, s);
-    this.#createPlane(this.#planeY, COLOR_Y, s, 0.0, 0.0, 0.0, 0.0, s);
-    this.#createPlane(this.#planeZ, COLOR_Z, s, 0.0, 0.0, 0.0, s, 0.0);
+    this._createPlane(this._planeX, COLOR_X, 0.0, s, 0.0, 0.0, 0.0, s);
+    this._createPlane(this._planeY, COLOR_Y, s, 0.0, 0.0, 0.0, 0.0, s);
+    this._createPlane(this._planeZ, COLOR_Z, s, 0.0, 0.0, 0.0, s, 0.0);
   }
 
-  #createCircle(rot, rad, color, radius = ROT_RADIUS, mthick = 1.0) {
+  _createCircle(rot, rad, color, radius = ROT_RADIUS, mthick = 1.0) {
     vec3.copy(rot._color, color);
     rot._pickGeo = Primitives.createTorus(
-      this.#gl,
+      this._gl,
       radius,
       THICKNESS_PICK * mthick,
       rad,
@@ -288,63 +288,63 @@ class Gizmo {
       64
     );
     rot._pickGeo._gizmo = rot;
-    rot._drawGeo = Primitives.createTorus(this.#gl, radius, THICKNESS * mthick, rad, 6, 64);
+    rot._drawGeo = Primitives.createTorus(this._gl, radius, THICKNESS * mthick, rad, 6, 64);
     rot._drawGeo.setShaderType(Enums.Shader.FLAT);
   }
 
-  #initRotate() {
-    this.#createCircle(this.#rotX, Math.PI, COLOR_X);
-    this.#createCircle(this.#rotY, Math.PI, COLOR_Y);
-    this.#createCircle(this.#rotZ, Math.PI, COLOR_Z);
-    this.#createCircle(this.#rotW, Math.PI * 2, COLOR_GREY);
+  _initRotate() {
+    this._createCircle(this._rotX, Math.PI, COLOR_X);
+    this._createCircle(this._rotY, Math.PI, COLOR_Y);
+    this._createCircle(this._rotZ, Math.PI, COLOR_Z);
+    this._createCircle(this._rotW, Math.PI * 2, COLOR_GREY);
   }
 
-  #createCube(sca, axis, color) {
+  _createCube(sca, axis, color) {
     var mat = sca._baseMatrix;
     mat4.rotate(mat, mat, Math.PI * 0.5, axis);
     mat4.translate(mat, mat, [0.0, ROT_RADIUS, 0.0]);
     vec3.copy(sca._color, color);
-    sca._pickGeo = Primitives.createCube(this.#gl, CUBE_SIDE_PICK);
+    sca._pickGeo = Primitives.createCube(this._gl, CUBE_SIDE_PICK);
     sca._pickGeo._gizmo = sca;
-    sca._drawGeo = Primitives.createCube(this.#gl, CUBE_SIDE);
+    sca._drawGeo = Primitives.createCube(this._gl, CUBE_SIDE);
     sca._drawGeo.setShaderType(Enums.Shader.FLAT);
   }
 
-  #initScale() {
+  _initScale() {
     var axis: vec3 = [0.0, 0.0, 0.0];
-    this.#createCube(this.#scaleX, vec3.set(axis, 0.0, 0.0, -1.0), COLOR_X);
-    this.#createCube(this.#scaleY, vec3.set(axis, 0.0, 1.0, 0.0), COLOR_Y);
-    this.#createCube(this.#scaleZ, vec3.set(axis, 1.0, 0.0, 0.0), COLOR_Z);
-    this.#createCircle(this.#scaleW, Math.PI * 2, COLOR_SW, SCALE_RADIUS, 2.0);
+    this._createCube(this._scaleX, vec3.set(axis, 0.0, 0.0, -1.0), COLOR_X);
+    this._createCube(this._scaleY, vec3.set(axis, 0.0, 1.0, 0.0), COLOR_Y);
+    this._createCube(this._scaleZ, vec3.set(axis, 1.0, 0.0, 0.0), COLOR_Z);
+    this._createCircle(this._scaleW, Math.PI * 2, COLOR_SW, SCALE_RADIUS, 2.0);
   }
 
-  #updateArcRotation(eye) {
+  _updateArcRotation(eye) {
     // xyz arc
     _TMP_QUAT[0] = eye[2];
     _TMP_QUAT[1] = 0.0;
     _TMP_QUAT[2] = -eye[0];
     _TMP_QUAT[3] = 1.0 + eye[1];
     quat.normalize(_TMP_QUAT, _TMP_QUAT);
-    mat4.fromQuat(this.#rotW._baseMatrix, _TMP_QUAT);
-    mat4.fromQuat(this.#scaleW._baseMatrix, _TMP_QUAT);
+    mat4.fromQuat(this._rotW._baseMatrix, _TMP_QUAT);
+    mat4.fromQuat(this._scaleW._baseMatrix, _TMP_QUAT);
 
     // x arc
     quat.rotateZ(_TMP_QUAT, quat.identity(_TMP_QUAT), Math.PI * 0.5);
     quat.rotateY(_TMP_QUAT, _TMP_QUAT, Math.atan2(-eye[1], -eye[2]));
-    mat4.fromQuat(this.#rotX._baseMatrix, _TMP_QUAT);
+    mat4.fromQuat(this._rotX._baseMatrix, _TMP_QUAT);
 
     // y arc
     quat.rotateY(_TMP_QUAT, quat.identity(_TMP_QUAT), Math.atan2(-eye[0], -eye[2]));
-    mat4.fromQuat(this.#rotY._baseMatrix, _TMP_QUAT);
+    mat4.fromQuat(this._rotY._baseMatrix, _TMP_QUAT);
 
     // z arc
     quat.rotateX(_TMP_QUAT, quat.identity(_TMP_QUAT), Math.PI * 0.5);
     quat.rotateY(_TMP_QUAT, _TMP_QUAT, Math.atan2(-eye[0], eye[1]));
-    mat4.fromQuat(this.#rotZ._baseMatrix, _TMP_QUAT);
+    mat4.fromQuat(this._rotZ._baseMatrix, _TMP_QUAT);
   }
 
-  #computeCenterGizmo(center: vec3 = [0.0, 0.0, 0.0]) {
-    var meshes = this.#main.getSelectedMeshes();
+  _computeCenterGizmo(center: vec3 = [0.0, 0.0, 0.0]) {
+    var meshes = this._main.getSelectedMeshes();
 
     var acc: vec3 = [0.0, 0.0, 0.0];
     var icenter: vec3 = [0.0, 0.0, 0.0];
@@ -358,127 +358,127 @@ class Gizmo {
     return center;
   }
 
-  #updateMatrices() {
-    var camera = this.#main.getCamera();
-    var trMesh = this.#computeCenterGizmo();
+  _updateMatrices() {
+    var camera = this._main.getCamera();
+    var trMesh = this._computeCenterGizmo();
     var eye = camera.computePosition();
 
-    this.#lastDistToEye = this.#isEditing ? this.#lastDistToEye : vec3.dist(eye, trMesh);
-    var scaleFactor = (this.#lastDistToEye * GIZMO_SIZE) / camera.getConstantScreen();
+    this._lastDistToEye = this._isEditing ? this._lastDistToEye : vec3.dist(eye, trMesh);
+    var scaleFactor = (this._lastDistToEye * GIZMO_SIZE) / camera.getConstantScreen();
 
     var traScale = mat4.create();
     mat4.translate(traScale, traScale, trMesh);
     mat4.scale(traScale, traScale, [scaleFactor, scaleFactor, scaleFactor]);
 
     // manage arc stuffs
-    this.#updateArcRotation(vec3.normalize(eye, vec3.sub(eye, trMesh, eye)));
+    this._updateArcRotation(vec3.normalize(eye, vec3.sub(eye, trMesh, eye)));
 
-    this.#transX.updateFinalMatrix(traScale);
-    this.#transY.updateFinalMatrix(traScale);
-    this.#transZ.updateFinalMatrix(traScale);
+    this._transX.updateFinalMatrix(traScale);
+    this._transY.updateFinalMatrix(traScale);
+    this._transZ.updateFinalMatrix(traScale);
 
-    this.#planeX.updateFinalMatrix(traScale);
-    this.#planeY.updateFinalMatrix(traScale);
-    this.#planeZ.updateFinalMatrix(traScale);
+    this._planeX.updateFinalMatrix(traScale);
+    this._planeY.updateFinalMatrix(traScale);
+    this._planeZ.updateFinalMatrix(traScale);
 
-    this.#rotX.updateFinalMatrix(traScale);
-    this.#rotY.updateFinalMatrix(traScale);
-    this.#rotZ.updateFinalMatrix(traScale);
-    this.#rotW.updateFinalMatrix(traScale);
+    this._rotX.updateFinalMatrix(traScale);
+    this._rotY.updateFinalMatrix(traScale);
+    this._rotZ.updateFinalMatrix(traScale);
+    this._rotW.updateFinalMatrix(traScale);
 
-    this.#scaleX.updateFinalMatrix(traScale);
-    this.#scaleY.updateFinalMatrix(traScale);
-    this.#scaleZ.updateFinalMatrix(traScale);
-    this.#scaleW.updateFinalMatrix(traScale);
+    this._scaleX.updateFinalMatrix(traScale);
+    this._scaleY.updateFinalMatrix(traScale);
+    this._scaleZ.updateFinalMatrix(traScale);
+    this._scaleW.updateFinalMatrix(traScale);
   }
 
-  #drawGizmo(elt) {
+  _drawGizmo(elt) {
     elt.updateMatrix();
     var drawGeo = elt._drawGeo;
     drawGeo.setFlatColor(elt._isSelected ? elt._colorSelect : elt._color);
-    drawGeo.updateMatrices(this.#main.getCamera());
-    drawGeo.render(this.#main);
+    drawGeo.updateMatrices(this._main.getCamera());
+    drawGeo.render(this._main);
   }
 
-  #updateLineHelper(x1, y1, x2, y2) {
-    var vAr = this.#lineHelper.getVertices();
-    var main = this.#main;
+  _updateLineHelper(x1, y1, x2, y2) {
+    var vAr = this._lineHelper.getVertices();
+    var main = this._main;
     var width = main.getCanvasWidth();
     var height = main.getCanvasHeight();
     vAr[0] = (x1 / width) * 2.0 - 1.0;
     vAr[1] = ((height - y1) / height) * 2.0 - 1.0;
     vAr[3] = (x2 / width) * 2.0 - 1.0;
     vAr[4] = ((height - y2) / height) * 2.0 - 1.0;
-    this.#lineHelper.updateVertexBuffer();
+    this._lineHelper.updateVertexBuffer();
   }
 
-  #saveEditMatrices() {
-    var meshes = this.#main.getSelectedMeshes();
+  _saveEditMatrices() {
+    var meshes = this._main.getSelectedMeshes();
 
     // translation part
-    var center = this.#computeCenterGizmo();
-    mat4.translate(this.#editTrans, mat4.identity(this.#editTrans), center);
-    mat4.invert(this.#editTransInv, this.#editTrans);
+    var center = this._computeCenterGizmo();
+    mat4.translate(this._editTrans, mat4.identity(this._editTrans), center);
+    mat4.invert(this._editTransInv, this._editTrans);
 
     for (var i = 0; i < meshes.length; ++i) {
-      this.#editLocal[i] = mat4.create();
-      this.#editScaleRot[i] = mat4.create();
-      this.#editLocalInv[i] = mat4.create();
-      this.#editScaleRotInv[i] = mat4.create();
+      this._editLocal[i] = mat4.create();
+      this._editScaleRot[i] = mat4.create();
+      this._editLocalInv[i] = mat4.create();
+      this._editScaleRotInv[i] = mat4.create();
 
       // mesh local matrix
-      mat4.copy(this.#editLocal[i], meshes[i].getMatrix());
+      mat4.copy(this._editLocal[i], meshes[i].getMatrix());
 
       // rotation + scale part
-      mat4.copy(this.#editScaleRot[i], this.#editLocal[i]);
-      this.#editScaleRot[i][12] = this.#editScaleRot[i][13] = this.#editScaleRot[i][14] = 0.0;
+      mat4.copy(this._editScaleRot[i], this._editLocal[i]);
+      this._editScaleRot[i][12] = this._editScaleRot[i][13] = this._editScaleRot[i][14] = 0.0;
 
       // precomputes the invert
-      mat4.invert(this.#editLocalInv[i], this.#editLocal[i]);
-      mat4.invert(this.#editScaleRotInv[i], this.#editScaleRot[i]);
+      mat4.invert(this._editLocalInv[i], this._editLocal[i]);
+      mat4.invert(this._editScaleRotInv[i], this._editScaleRot[i]);
     }
   }
 
-  #startRotateEdit() {
-    if (this.#selected == null) {
+  _startRotateEdit() {
+    if (this._selected == null) {
       return;
     }
-    var main = this.#main;
+    var main = this._main;
     var camera = main.getCamera();
 
     // 3d origin (center of gizmo)
     var projCenter: vec3 = [0.0, 0.0, 0.0];
-    this.#computeCenterGizmo(projCenter);
+    this._computeCenterGizmo(projCenter);
     vec3.copy(projCenter, camera.project(projCenter));
 
     // compute tangent direction and project it on screen
-    var dir = this.#editLineDirection;
-    var sign = this.#selected._nbAxis === 0 ? -1.0 : 1.0;
-    var lastInter = this.#selected._lastInter;
+    var dir = this._editLineDirection;
+    var sign = this._selected._nbAxis === 0 ? -1.0 : 1.0;
+    var lastInter = this._selected._lastInter;
     vec3.set(dir, -sign * lastInter[2], -sign * lastInter[1], sign * lastInter[0]);
-    vec3.transformMat4(dir, dir, this.#selected._finalMatrix);
+    vec3.transformMat4(dir, dir, this._selected._finalMatrix);
     vec3.copy(dir, camera.project(dir));
 
     vec3.normalize(dir, vec3.sub(dir, dir, projCenter));
 
-    vec3.set(this.#editLineOrigin, main._mouseX, main._mouseY, 0.0);
+    vec3.set(this._editLineOrigin, main._mouseX, main._mouseY, 0.0);
   }
 
-  #startTranslateEdit() {
-    if (this.#selected == null) {
+  _startTranslateEdit() {
+    if (this._selected == null) {
       return;
     }
-    var main = this.#main;
+    var main = this._main;
     var camera = main.getCamera();
 
-    var origin = this.#editLineOrigin;
-    var dir = this.#editLineDirection;
+    var origin = this._editLineOrigin;
+    var dir = this._editLineDirection;
 
     // 3d origin (center of gizmo)
-    this.#computeCenterGizmo(origin);
+    this._computeCenterGizmo(origin);
 
     // 3d direction
-    var nbAxis = this.#selected._nbAxis;
+    var nbAxis = this._selected._nbAxis;
     if (nbAxis !== -1)
       // if -1, we don't care about dir vector
       vec3.set(dir, 0.0, 0.0, 0.0)[nbAxis] = 1.0;
@@ -490,48 +490,48 @@ class Gizmo {
 
     vec3.normalize(dir, vec3.sub(dir, dir, origin));
 
-    var offset = this.#editOffset;
+    var offset = this._editOffset;
     offset[0] = main._mouseX - origin[0];
     offset[1] = main._mouseY - origin[1];
   }
 
-  #startPlaneEdit() {
-    var main = this.#main;
+  _startPlaneEdit() {
+    var main = this._main;
     var camera = main.getCamera();
 
-    var origin = this.#editLineOrigin;
+    var origin = this._editLineOrigin;
 
     // 3d origin (center of gizmo)
-    this.#computeCenterGizmo(origin);
+    this._computeCenterGizmo(origin);
 
     vec3.copy(origin, camera.project(origin));
 
-    var offset = this.#editOffset;
+    var offset = this._editOffset;
     offset[0] = main._mouseX - origin[0];
     offset[1] = main._mouseY - origin[1];
-    vec3.set(this.#editLineOrigin, main._mouseX, main._mouseY, 0.0);
+    vec3.set(this._editLineOrigin, main._mouseX, main._mouseY, 0.0);
   }
 
-  #startScaleEdit() {
-    this.#startTranslateEdit();
+  _startScaleEdit() {
+    this._startTranslateEdit();
   }
 
-  #updateRotateEdit() {
-    if (this.#selected == null) {
+  _updateRotateEdit() {
+    if (this._selected == null) {
       return;
     }
 
-    var main = this.#main;
+    var main = this._main;
 
-    var origin = this.#editLineOrigin;
-    var dir = this.#editLineDirection;
+    var origin = this._editLineOrigin;
+    var dir = this._editLineDirection;
 
     var vec: vec3 = [main._mouseX, main._mouseY, 0.0];
     vec3.sub(vec, vec, origin);
     var dist = vec3.dot(vec, dir);
 
     // helper line
-    this.#updateLineHelper(
+    this._updateLineHelper(
       origin[0],
       origin[1],
       origin[0] + dir[0] * dist,
@@ -540,9 +540,9 @@ class Gizmo {
 
     var angle = (7 * dist) / Math.min(main.getCanvasWidth(), main.getCanvasHeight());
     angle %= Math.PI * 2;
-    var nbAxis = this.#selected._nbAxis;
+    var nbAxis = this._selected._nbAxis;
 
-    var meshes = this.#main.getSelectedMeshes();
+    var meshes = this._main.getSelectedMeshes();
     for (var i = 0; i < meshes.length; ++i) {
       var mrot = meshes[i].getEditMatrix();
       mat4.identity(mrot);
@@ -550,68 +550,68 @@ class Gizmo {
       else if (nbAxis === 1) mat4.rotateY(mrot, mrot, -angle);
       else if (nbAxis === 2) mat4.rotateZ(mrot, mrot, -angle);
 
-      this.#scaleRotateEditMatrix(mrot, i);
+      this._scaleRotateEditMatrix(mrot, i);
     }
 
     main.render();
   }
 
-  #updateTranslateEdit() {
-    if (this.#selected == null) {
+  _updateTranslateEdit() {
+    if (this._selected == null) {
       return;
     }
-    var main = this.#main;
+    var main = this._main;
     var camera = main.getCamera();
 
-    var origin = this.#editLineOrigin;
-    var dir = this.#editLineDirection;
+    var origin = this._editLineOrigin;
+    var dir = this._editLineDirection;
 
     var vec: vec3 = [main._mouseX, main._mouseY, 0.0];
     vec3.sub(vec, vec, origin);
-    vec3.sub(vec, vec, this.#editOffset);
+    vec3.sub(vec, vec, this._editOffset);
     vec3.scaleAndAdd(vec, origin, dir, vec3.dot(vec, dir));
 
     // helper line
-    this.#updateLineHelper(origin[0], origin[1], vec[0], vec[1]);
+    this._updateLineHelper(origin[0], origin[1], vec[0], vec[1]);
 
     var near = camera.unproject(vec[0], vec[1], 0.0);
     var far = camera.unproject(vec[0], vec[1], 0.1);
 
-    vec3.transformMat4(near, near, this.#editTransInv);
-    vec3.transformMat4(far, far, this.#editTransInv);
+    vec3.transformMat4(near, near, this._editTransInv);
+    vec3.transformMat4(far, far, this._editTransInv);
 
     // intersection line line
     vec3.normalize(vec, vec3.sub(vec, far, near));
 
     var inter: vec3 = [0.0, 0.0, 0.0];
-    inter[this.#selected._nbAxis] = 1.0;
+    inter[this._selected._nbAxis] = 1.0;
 
     var a01 = -vec3.dot(vec, inter);
     var b0 = vec3.dot(near, vec);
     var det = Math.abs(1.0 - a01 * a01);
 
     var b1 = -vec3.dot(near, inter);
-    inter[this.#selected._nbAxis] = (a01 * b0 - b1) / det;
+    inter[this._selected._nbAxis] = (a01 * b0 - b1) / det;
 
-    this.#updateMatrixTranslate(inter);
+    this._updateMatrixTranslate(inter);
 
     main.render();
   }
 
-  #updatePlaneEdit() {
-    if (this.#selected == null) {
+  _updatePlaneEdit() {
+    if (this._selected == null) {
       return;
     }
-    var main = this.#main;
+    var main = this._main;
     var camera = main.getCamera();
 
     var vec: vec3 = [main._mouseX, main._mouseY, 0.0];
-    vec3.sub(vec, vec, this.#editOffset);
+    vec3.sub(vec, vec, this._editOffset);
 
     // helper line
-    this.#updateLineHelper(
-      this.#editLineOrigin[0],
-      this.#editLineOrigin[1],
+    this._updateLineHelper(
+      this._editLineOrigin[0],
+      this._editLineOrigin[1],
       main._mouseX,
       main._mouseY
     );
@@ -619,12 +619,12 @@ class Gizmo {
     var near = camera.unproject(vec[0], vec[1], 0.0);
     var far = camera.unproject(vec[0], vec[1], 0.1);
 
-    vec3.transformMat4(near, near, this.#editTransInv);
-    vec3.transformMat4(far, far, this.#editTransInv);
+    vec3.transformMat4(near, near, this._editTransInv);
+    vec3.transformMat4(far, far, this._editTransInv);
 
     // intersection line plane
     var inter: vec3 = [0.0, 0.0, 0.0];
-    inter[this.#selected._nbAxis] = 1.0;
+    inter[this._selected._nbAxis] = 1.0;
 
     var dist1 = vec3.dot(near, inter);
     var dist2 = vec3.dot(far, inter);
@@ -637,17 +637,17 @@ class Gizmo {
     inter[1] = near[1] + (far[1] - near[1]) * val;
     inter[2] = near[2] + (far[2] - near[2]) * val;
 
-    this.#updateMatrixTranslate(inter);
+    this._updateMatrixTranslate(inter);
 
     main.render();
   }
 
-  #updateMatrixTranslate(inter) {
+  _updateMatrixTranslate(inter) {
     var tmp: vec3 = [0, 0, 0];
 
-    var meshes = this.#main.getSelectedMeshes();
+    var meshes = this._main.getSelectedMeshes();
     for (var i = 0; i < meshes.length; ++i) {
-      vec3.transformMat4(tmp, inter, this.#editScaleRotInv[i]);
+      vec3.transformMat4(tmp, inter, this._editScaleRotInv[i]);
 
       var edim = meshes[i].getEditMatrix();
       mat4.identity(edim);
@@ -655,16 +655,16 @@ class Gizmo {
     }
   }
 
-  #updateScaleEdit() {
-    if (this.#selected == null) {
+  _updateScaleEdit() {
+    if (this._selected == null) {
       return;
     }
-    var main = this.#main;
+    var main = this._main;
     var mesh = main.getMesh();
 
-    var origin = this.#editLineOrigin;
-    var dir = this.#editLineDirection;
-    var nbAxis = this.#selected._nbAxis;
+    var origin = this._editLineOrigin;
+    var dir = this._editLineDirection;
+    var nbAxis = this._selected._nbAxis;
 
     var vec: vec3 = [main._mouseX, main._mouseY, 0.0];
     if (nbAxis !== -1) {
@@ -673,9 +673,9 @@ class Gizmo {
     }
 
     // helper line
-    this.#updateLineHelper(origin[0], origin[1], vec[0], vec[1]);
+    this._updateLineHelper(origin[0], origin[1], vec[0], vec[1]);
 
-    var distOffset = vec3.len(this.#editOffset);
+    var distOffset = vec3.len(this._editOffset);
     var inter: vec3 = [1.0, 1.0, 1.0];
     var scaleMult = Math.max(-0.99, (vec3.dist(origin, vec) - distOffset) / distOffset);
     if (nbAxis === -1) {
@@ -686,129 +686,129 @@ class Gizmo {
       inter[nbAxis] += scaleMult;
     }
 
-    var meshes = this.#main.getSelectedMeshes();
+    var meshes = this._main.getSelectedMeshes();
     for (var i = 0; i < meshes.length; ++i) {
       var edim = meshes[i].getEditMatrix();
       mat4.identity(edim);
       mat4.scale(edim, edim, inter);
 
-      this.#scaleRotateEditMatrix(edim, i);
+      this._scaleRotateEditMatrix(edim, i);
     }
 
     main.render();
   }
 
-  #scaleRotateEditMatrix(edit, i) {
-    mat4.mul(edit, this.#editTrans, edit);
-    mat4.mul(edit, edit, this.#editTransInv);
+  _scaleRotateEditMatrix(edit, i) {
+    mat4.mul(edit, this._editTrans, edit);
+    mat4.mul(edit, edit, this._editTransInv);
 
-    mat4.mul(edit, this.#editLocalInv[i], edit);
-    mat4.mul(edit, edit, this.#editLocal[i]);
+    mat4.mul(edit, this._editLocalInv[i], edit);
+    mat4.mul(edit, edit, this._editLocal[i]);
   }
 
   addGizmoToScene(scene) {
-    scene.push(this.#transX._drawGeo);
-    scene.push(this.#transY._drawGeo);
-    scene.push(this.#transZ._drawGeo);
+    scene.push(this._transX._drawGeo);
+    scene.push(this._transY._drawGeo);
+    scene.push(this._transZ._drawGeo);
 
-    scene.push(this.#planeX._drawGeo);
-    scene.push(this.#planeY._drawGeo);
-    scene.push(this.#planeZ._drawGeo);
+    scene.push(this._planeX._drawGeo);
+    scene.push(this._planeY._drawGeo);
+    scene.push(this._planeZ._drawGeo);
 
-    scene.push(this.#rotX._drawGeo);
-    scene.push(this.#rotY._drawGeo);
-    scene.push(this.#rotZ._drawGeo);
-    scene.push(this.#rotW._drawGeo);
+    scene.push(this._rotX._drawGeo);
+    scene.push(this._rotY._drawGeo);
+    scene.push(this._rotZ._drawGeo);
+    scene.push(this._rotW._drawGeo);
 
-    scene.push(this.#scaleX._drawGeo);
-    scene.push(this.#scaleY._drawGeo);
-    scene.push(this.#scaleZ._drawGeo);
-    scene.push(this.#scaleW._drawGeo);
+    scene.push(this._scaleX._drawGeo);
+    scene.push(this._scaleY._drawGeo);
+    scene.push(this._scaleZ._drawGeo);
+    scene.push(this._scaleW._drawGeo);
 
     return scene;
   }
 
   render() {
-    this.#updateMatrices();
+    this._updateMatrices();
 
-    var type = this.#isEditing && this.#selected ? this.#selected._type : this.#activatedType;
+    var type = this._isEditing && this._selected ? this._selected._type : this._activatedType;
 
-    if (type & ROT_W) this.#drawGizmo(this.#rotW);
+    if (type & ROT_W) this._drawGizmo(this._rotW);
 
-    if (type & TRANS_X) this.#drawGizmo(this.#transX);
-    if (type & TRANS_Y) this.#drawGizmo(this.#transY);
-    if (type & TRANS_Z) this.#drawGizmo(this.#transZ);
+    if (type & TRANS_X) this._drawGizmo(this._transX);
+    if (type & TRANS_Y) this._drawGizmo(this._transY);
+    if (type & TRANS_Z) this._drawGizmo(this._transZ);
 
-    if (type & PLANE_X) this.#drawGizmo(this.#planeX);
-    if (type & PLANE_Y) this.#drawGizmo(this.#planeY);
-    if (type & PLANE_Z) this.#drawGizmo(this.#planeZ);
+    if (type & PLANE_X) this._drawGizmo(this._planeX);
+    if (type & PLANE_Y) this._drawGizmo(this._planeY);
+    if (type & PLANE_Z) this._drawGizmo(this._planeZ);
 
-    if (type & ROT_X) this.#drawGizmo(this.#rotX);
-    if (type & ROT_Y) this.#drawGizmo(this.#rotY);
-    if (type & ROT_Z) this.#drawGizmo(this.#rotZ);
+    if (type & ROT_X) this._drawGizmo(this._rotX);
+    if (type & ROT_Y) this._drawGizmo(this._rotY);
+    if (type & ROT_Z) this._drawGizmo(this._rotZ);
 
-    if (type & SCALE_X) this.#drawGizmo(this.#scaleX);
-    if (type & SCALE_Y) this.#drawGizmo(this.#scaleY);
-    if (type & SCALE_Z) this.#drawGizmo(this.#scaleZ);
-    if (type & SCALE_W) this.#drawGizmo(this.#scaleW);
+    if (type & SCALE_X) this._drawGizmo(this._scaleX);
+    if (type & SCALE_Y) this._drawGizmo(this._scaleY);
+    if (type & SCALE_Z) this._drawGizmo(this._scaleZ);
+    if (type & SCALE_W) this._drawGizmo(this._scaleW);
 
-    if (this.#isEditing) this.#lineHelper.render(this.#main);
+    if (this._isEditing) this._lineHelper.render(this._main);
   }
 
   onMouseOver() {
 
-    if (this.#isEditing && this.#selected != null) {
-      var type = this.#selected._type;
-      if (type & ROT_XYZ) this.#updateRotateEdit();
-      else if (type & TRANS_XYZ) this.#updateTranslateEdit();
-      else if (type & PLANE_XYZ) this.#updatePlaneEdit();
-      else if (type & SCALE_XYZW) this.#updateScaleEdit();
+    if (this._isEditing && this._selected != null) {
+      var type = this._selected._type;
+      if (type & ROT_XYZ) this._updateRotateEdit();
+      else if (type & TRANS_XYZ) this._updateTranslateEdit();
+      else if (type & PLANE_XYZ) this._updatePlaneEdit();
+      else if (type & SCALE_XYZW) this._updateScaleEdit();
 
       return true;
     }
 
-    var main = this.#main;
+    var main = this._main;
     var picking = main.getPicking();
     var mx = main._mouseX;
     var my = main._mouseY;
-    var pickables = this.#pickables;
+    var pickables = this._pickables;
     picking.intersectionMouseMeshes(pickables, mx, my);
 
-    if (this.#selected) {
-      this.#selected._isSelected = false;
+    if (this._selected) {
+      this._selected._isSelected = false;
     }
     var geo = picking.getMesh();
     if (!geo) {
-      this.#selected = null;
+      this._selected = null;
       return false;
     }
 
-    this.#selected = geo._gizmo;
-    if (this.#selected != null) {
-      this.#selected._isSelected = true;
-      vec3.copy(this.#selected._lastInter, picking.getIntersectionPoint());
+    this._selected = geo._gizmo;
+    if (this._selected != null) {
+      this._selected._isSelected = true;
+      vec3.copy(this._selected._lastInter, picking.getIntersectionPoint());
     }
     return true;
   }
 
   onMouseDown() {
-    var sel = this.#selected;
+    var sel = this._selected;
     if (!sel) return false;
 
-    this.#isEditing = true;
+    this._isEditing = true;
     var type = sel._type;
-    this.#saveEditMatrices();
+    this._saveEditMatrices();
 
-    if (type & ROT_XYZ) this.#startRotateEdit();
-    else if (type & TRANS_XYZ) this.#startTranslateEdit();
-    else if (type & PLANE_XYZ) this.#startPlaneEdit();
-    else if (type & SCALE_XYZW) this.#startScaleEdit();
+    if (type & ROT_XYZ) this._startRotateEdit();
+    else if (type & TRANS_XYZ) this._startTranslateEdit();
+    else if (type & PLANE_XYZ) this._startPlaneEdit();
+    else if (type & SCALE_XYZW) this._startScaleEdit();
 
     return true;
   }
 
   onMouseUp() {
-    this.#isEditing = false;
+    this._isEditing = false;
   }
 }
 

--- a/src/editing/HoleFilling.ts
+++ b/src/editing/HoleFilling.ts
@@ -5,13 +5,13 @@ import Mesh from '../mesh/Mesh';
 
 
 class Edge {
-  #v1;
-  #v2;
-  #previous;
-  #next;
+  _v1;
+  _v2;
+  _previous;
+  _next;
   constructor(v1, v2) {
-    this.#v1 = v1;
-    this.#v2 = v2;
+    this._v1 = v1;
+    this._v2 = v2;
   }
 }
 

--- a/src/editing/SculptManager.ts
+++ b/src/editing/SculptManager.ts
@@ -4,53 +4,53 @@ import Enums from '../misc/Enums';
 
 class SculptManager {
 
-  #main;
+  _main;
   /** Sculpting mode */
-  #toolIndex = Enums.Tools.BRUSH;
+  _toolIndex = Enums.Tools.BRUSH;
   /** The sculpting tools */
-  #tools: any[] = [];
+  _tools: any[] = [];
   /** Symmetry */
-  #symmetry = true;
+  _symmetry = true;
   /** Continuous sculpting */
-  #continuous = false;
+  _continuous = false;
   /** Continuous sculpting times */
-  #sculptTimer = -1;
+  _sculptTimer = -1;
   /** Selector geometry ( the red hover circle ) */
-  #selection;
+  _selection;
 
   constructor(main) {
-    this.#main = main;
-    this.#selection = new Selection(main._gl);
+    this._main = main;
+    this._selection = new Selection(main._gl);
     this.init();
   }
 
   setToolIndex(id) {
-    this.#toolIndex = id;
+    this._toolIndex = id;
   }
 
   getToolIndex() {
-    return this.#toolIndex;
+    return this._toolIndex;
   }
 
   getCurrentTool() {
-    return this.#tools[this.#toolIndex];
+    return this._tools[this._toolIndex];
   }
 
   getSymmetry() {
-    return this.#symmetry;
+    return this._symmetry;
   }
 
   getTool(index) {
-    return this.#tools[index];
+    return this._tools[index];
   }
 
   getSelection() {
-    return this.#selection;
+    return this._selection;
   }
 
   init() {
-    var main = this.#main;
-    var tools = this.#tools;
+    var main = this._main;
+    var tools = this._tools;
     for (var i = 0, nb = Tools.length; i < nb; ++i) {
       if (Tools[i]) tools[i] = new Tools[i](main);
     }
@@ -58,7 +58,7 @@ class SculptManager {
 
   // TODO Should this be refactored onto tools themselves?
   canBeContinuous() {
-    switch (this.#toolIndex) {
+    switch (this._toolIndex) {
       case Enums.Tools.TWIST:
       case Enums.Tools.MOVE:
       case Enums.Tools.DRAG:
@@ -71,22 +71,22 @@ class SculptManager {
   }
 
   isUsingContinuous() {
-    return this.#continuous && this.canBeContinuous();
+    return this._continuous && this.canBeContinuous();
   }
 
   start(ctrl) {
     var tool = this.getCurrentTool();
     var canEdit = tool.start(ctrl);
-    if (this.#main.getPicking().getMesh() && this.isUsingContinuous())
-      this.#sculptTimer = window.setInterval(tool._cbContinuous, 16.6);
+    if (this._main.getPicking().getMesh() && this.isUsingContinuous())
+      this._sculptTimer = window.setInterval(tool._cbContinuous, 16.6);
     return canEdit;
   }
 
   end() {
     this.getCurrentTool().end();
-    if (this.#sculptTimer !== -1) {
-      clearInterval(this.#sculptTimer);
-      this.#sculptTimer = -1;
+    if (this._sculptTimer !== -1) {
+      clearInterval(this._sculptTimer);
+      this._sculptTimer = -1;
     }
   }
 
@@ -101,7 +101,7 @@ class SculptManager {
   }
 
   postRender() {
-    this.getCurrentTool().postRender(this.#selection);
+    this.getCurrentTool().postRender(this._selection);
   }
 
   addSculptToScene(scene) {

--- a/src/editing/Subdivision.ts
+++ b/src/editing/Subdivision.ts
@@ -21,46 +21,46 @@ import Utils from '../misc/Utils';
 // Helper class
 class OddVertexComputer {
 
-  #vArOut;
-  #cArOut;
-  #mArOut;
-  #vAr;
-  #cAr;
-  #mAr;
-  #eAr;
-  #nbVertices;
-  #tagEdges;
+  _vArOut;
+  _cArOut;
+  _mArOut;
+  _vAr;
+  _cAr;
+  _mAr;
+  _eAr;
+  _nbVertices;
+  _tagEdges;
 
   constructor(mesh, vArOut, cArOut, mArOut) {
-    this.#vArOut = vArOut;
-    this.#cArOut = cArOut;
-    this.#mArOut = mArOut;
-    this.#vAr = mesh.getVertices();
-    this.#cAr = mesh.getColors();
-    this.#mAr = mesh.getMaterials();
-    this.#eAr = mesh.getEdges();
-    this.#nbVertices = mesh.getNbVertices();
-    this.#tagEdges = new Int32Array(mesh.getNbEdges());
+    this._vArOut = vArOut;
+    this._cArOut = cArOut;
+    this._mArOut = mArOut;
+    this._vAr = mesh.getVertices();
+    this._cAr = mesh.getColors();
+    this._mAr = mesh.getMaterials();
+    this._eAr = mesh.getEdges();
+    this._nbVertices = mesh.getNbVertices();
+    this._tagEdges = new Int32Array(mesh.getNbEdges());
   }
 
   get tagEdges() {
-    return this.#tagEdges
+    return this._tagEdges
   }
 
   computeTriangleEdgeVertex(iv1, iv2, iv3, ide) {
-    var vAr = this.#vAr;
-    var cAr = this.#cAr;
-    var mAr = this.#mAr;
-    var eAr = this.#eAr;
-    var vArOut = this.#vArOut;
-    var cArOut = this.#cArOut;
-    var mArOut = this.#mArOut;
-    var tagEdges = this.#tagEdges;
+    var vAr = this._vAr;
+    var cAr = this._cAr;
+    var mAr = this._mAr;
+    var eAr = this._eAr;
+    var vArOut = this._vArOut;
+    var cArOut = this._cArOut;
+    var mArOut = this._mArOut;
+    var tagEdges = this._tagEdges;
     var id1 = iv1 * 3;
     var id2 = iv2 * 3;
     var idOpp = iv3 * 3;
     var testEdge = tagEdges[ide] - 1;
-    var ivMid = testEdge === -1 ? this.#nbVertices++ : testEdge;
+    var ivMid = testEdge === -1 ? this._nbVertices++ : testEdge;
     var idMid = ivMid * 3;
     var edgeValue = eAr[ide];
     if (edgeValue === 1 || edgeValue >= 3 || Subdivision.LINEAR) {
@@ -111,20 +111,20 @@ class OddVertexComputer {
 
   /* eslint-disable @stylistic/max-len */
   computeQuadEdgeVertex(iv1, iv2, iv3, iv4, ide) {
-    var vAr = this.#vAr;
-    var cAr = this.#cAr;
-    var mAr = this.#mAr;
-    var eAr = this.#eAr;
-    var vArOut = this.#vArOut;
-    var cArOut = this.#cArOut;
-    var mArOut = this.#mArOut;
-    var tagEdges = this.#tagEdges;
+    var vAr = this._vAr;
+    var cAr = this._cAr;
+    var mAr = this._mAr;
+    var eAr = this._eAr;
+    var vArOut = this._vArOut;
+    var cArOut = this._cArOut;
+    var mArOut = this._mArOut;
+    var tagEdges = this._tagEdges;
     var id1 = iv1 * 3;
     var id2 = iv2 * 3;
     var idOpp = iv3 * 3;
     var idOpp2 = iv4 * 3;
     var testEdge = tagEdges[ide] - 1;
-    var ivMid = testEdge === -1 ? this.#nbVertices++ : testEdge;
+    var ivMid = testEdge === -1 ? this._nbVertices++ : testEdge;
     var idMid = ivMid * 3;
     var edgeValue = eAr[ide];
     if (edgeValue === 1 || edgeValue >= 3 || Subdivision.LINEAR) {
@@ -181,13 +181,13 @@ class OddVertexComputer {
     var id2 = iv2 * 3;
     var id3 = iv3 * 3;
     var id4 = iv4 * 3;
-    var vAr = this.#vAr;
-    var cAr = this.#cAr;
-    var mAr = this.#mAr;
-    var vArOut = this.#vArOut;
-    var cArOut = this.#cArOut;
-    var mArOut = this.#mArOut;
-    var ivCen = this.#nbVertices++;
+    var vAr = this._vAr;
+    var cAr = this._cAr;
+    var mAr = this._mAr;
+    var vArOut = this._vArOut;
+    var cArOut = this._cArOut;
+    var mArOut = this._mArOut;
+    var ivCen = this._nbVertices++;
     var idCen = ivCen * 3;
     vArOut[idCen] = 0.25 * (vAr[id1] + vAr[id2] + vAr[id3] + vAr[id4]);
     vArOut[idCen + 1] = 0.25 * (vAr[id1 + 1] + vAr[id2 + 1] + vAr[id3 + 1] + vAr[id4 + 1]);

--- a/src/editing/SurfaceNets.ts
+++ b/src/editing/SurfaceNets.ts
@@ -7,8 +7,8 @@
 class SurfaceNets {
 
   //Precompute edge table, like Paul Bourke does.
-  static #cubeEdges = SurfaceNets.computeCubeEdges();
-  static #edgeTable = SurfaceNets.computeEdgeTable(SurfaceNets.#cubeEdges);
+  static _cubeEdges = SurfaceNets.computeCubeEdges();
+  static _edgeTable = SurfaceNets.computeEdgeTable(SurfaceNets._cubeEdges);
   static BLOCK = false;
 
   // This is just the vertex number of each cube
@@ -191,9 +191,9 @@ class SurfaceNets {
           if (mask === 0 || mask === 0xff)
             continue;
           //Sum up edge intersections
-          var edgeMask = SurfaceNets.#edgeTable[mask];
+          var edgeMask = SurfaceNets._edgeTable[mask];
           buffer[m] = vertices.length / 3;
-          SurfaceNets.interpolateVertices(edgeMask, SurfaceNets.#cubeEdges, grid, x, vertices);
+          SurfaceNets.interpolateVertices(edgeMask, SurfaceNets._cubeEdges, grid, x, vertices);
           SurfaceNets.createFace(edgeMask, mask, buffer, R, m, x, faces);
         }
       }

--- a/src/math3d/Camera.ts
+++ b/src/math3d/Camera.ts
@@ -46,260 +46,260 @@ const _QUAT_COMP = [
 
 class Camera {
 
-  #main;
+  _main;
 
-  #mode; // SPHERICAL / PLANE
-  #projectionType; // ORTHOGRAPHIC
+  _mode; // SPHERICAL / PLANE
+  _projectionType; // ORTHOGRAPHIC
 
-  #quatRot: quat = [0.0, 0.0, 0.0, 1.0]; // quaternion rotation
-  #view = mat4.create(); // view matrix
-  #proj = mat4.create(); // projection matrix
-  #viewport = mat4.create(); // viewport matrix
+  _quatRot: quat = [0.0, 0.0, 0.0, 1.0]; // quaternion rotation
+  _view = mat4.create(); // view matrix
+  _proj = mat4.create(); // projection matrix
+  _viewport = mat4.create(); // viewport matrix
 
-  #lastNormalizedMouseXY: vec2 = [0.0, 0.0]; // last mouse position ( 0..1 )
-  #width = 0.0; // viewport width
-  #height = 0.0; // viewport height
+  _lastNormalizedMouseXY: vec2 = [0.0, 0.0]; // last mouse position ( 0..1 )
+  _width = 0.0; // viewport width
+  _height = 0.0; // viewport height
 
-  #speed = 0.0; // solve scale issue
-  #fov; // vertical field of view
+  _speed = 0.0; // solve scale issue
+  _fov; // vertical field of view
 
   // translation stuffs
-  #trans: vec3 = [0.0, 0.0, 30.0];
-  #moveX = 0; // free look (strafe), possible values : -1, 0, 1
-  #moveZ = 0; // free look (strafe), possible values : -1, 0, 1
+  _trans: vec3 = [0.0, 0.0, 30.0];
+  _moveX = 0; // free look (strafe), possible values : -1, 0, 1
+  _moveZ = 0; // free look (strafe), possible values : -1, 0, 1
 
   // pivot stuffs
-  #usePivot: boolean; // if rotation is centered around the picked point
-  #center: vec3 = [0.0, 0.0, 0.0]; // center of rotation
-  #offset: vec3 = [0.0, 0.0, 0.0];
+  _usePivot: boolean; // if rotation is centered around the picked point
+  _center: vec3 = [0.0, 0.0, 0.0]; // center of rotation
+  _offset: vec3 = [0.0, 0.0, 0.0];
 
   // orbit camera
-  #rotX = 0.0; // x rot for orbit camera
-  #rotY = 0.0; // y rot for orbit camera
+  _rotX = 0.0; // x rot for orbit camera
+  _rotY = 0.0; // y rot for orbit camera
 
   // near far
-  #near = 0.05;
-  #far = 5000.0;
+  _near = 0.05;
+  _far = 5000.0;
 
-  #timers = {}; // animation timers
+  _timers = {}; // animation timers
 
-  #lastBBox: any = null;
+  _lastBBox: any = null;
 
   // Scratch values
-  #tmp_vec2: vec2 = [0.0, 0.0];
-  #tmp_vec3: vec3 = [0.0, 0.0, 0.0];
-  #tmp_vec3_2: vec3 = [0.0, 0.0, 0.0];
-  #tmp_quat: quat = [0.0, 0.0, 0.0, 1.0];
-  #tmp_mat: mat4 = mat4.create();
+  _tmp_vec2: vec2 = [0.0, 0.0];
+  _tmp_vec3: vec3 = [0.0, 0.0, 0.0];
+  _tmp_vec3_2: vec3 = [0.0, 0.0, 0.0];
+  _tmp_quat: quat = [0.0, 0.0, 0.0, 1.0];
+  _tmp_mat: mat4 = mat4.create();
 
   constructor(main) {
-    this.#main = main;
+    this._main = main;
 
     // Handle options
     var opts = getOptionsURL();
-    this.#mode = opts.cameramode || Enums.CameraMode.ORBIT; // SPHERICAL / PLANE
-    this.#projectionType = opts.projection || Enums.Projection.PERSPECTIVE; // ORTHOGRAPHIC
-    this.#fov = Math.min(opts.fov, 150); // vertical field of view
-    this.#usePivot = opts.pivot; // if rotation is centered around the picked point
+    this._mode = opts.cameramode || Enums.CameraMode.ORBIT; // SPHERICAL / PLANE
+    this._projectionType = opts.projection || Enums.Projection.PERSPECTIVE; // ORTHOGRAPHIC
+    this._fov = Math.min(opts.fov, 150); // vertical field of view
+    this._usePivot = opts.pivot; // if rotation is centered around the picked point
 
     this.resetView();
   }
 
   setProjectionType(type) {
-    this.#projectionType = type;
+    this._projectionType = type;
     this.updateProjection();
     this.updateView();
   }
 
   setMode(mode) {
-    this.#mode = mode;
+    this._mode = mode;
     if (mode === Enums.CameraMode.ORBIT)
       this.resetViewFront();
   }
 
   setFov(fov) {
-    this.#fov = fov;
+    this._fov = fov;
     this.updateView();
     this.optimizeNearFar();
   }
 
   setUsePivot(bool) {
-    this.#usePivot = bool;
+    this._usePivot = bool;
   }
 
   toggleUsePivot() {
-    this.#usePivot = !this.#usePivot;
+    this._usePivot = !this._usePivot;
   }
 
   getView() {
-    return this.#view;
+    return this._view;
   }
 
   getProjection() {
-    return this.#proj;
+    return this._proj;
   }
 
   getProjectionType() {
-    return this.#projectionType;
+    return this._projectionType;
   }
 
   isOrthographic() {
-    return this.#projectionType === Enums.Projection.ORTHOGRAPHIC;
+    return this._projectionType === Enums.Projection.ORTHOGRAPHIC;
   }
 
   getMode() {
-    return this.#mode;
+    return this._mode;
   }
 
   getFov() {
-    return this.#fov;
+    return this._fov;
   }
 
   getUsePivot() {
-    return this.#usePivot;
+    return this._usePivot;
   }
 
   getConstantScreen() {
-    var cwidth = this.#main.getCanvas().clientWidth;
-    if (this.#projectionType === Enums.Projection.ORTHOGRAPHIC)
+    var cwidth = this._main.getCanvas().clientWidth;
+    if (this._projectionType === Enums.Projection.ORTHOGRAPHIC)
       return cwidth / this.getOrthoZoom();
-    return cwidth * this.#proj[0];
+    return cwidth * this._proj[0];
   }
 
   start(mouseX, mouseY) {
-    this.#lastNormalizedMouseXY = Geometry.normalizedMouse(mouseX, mouseY, this.#width, this.#height);
-    if (!this.#usePivot)
+    this._lastNormalizedMouseXY = Geometry.normalizedMouse(mouseX, mouseY, this._width, this._height);
+    if (!this._usePivot)
       return;
-    var main = this.#main;
+    var main = this._main;
     var picking = main.getPicking();
     picking.intersectionMouseMeshes(main.getMeshes(), mouseX, mouseY);
     if (picking.getMesh()) {
-      vec3.transformMat4(this.#tmp_vec3, picking.getIntersectionPoint(), picking.getMesh().getMatrix());
-      this.setPivot(this.#tmp_vec3);
+      vec3.transformMat4(this._tmp_vec3, picking.getIntersectionPoint(), picking.getMesh().getMatrix());
+      this.setPivot(this._tmp_vec3);
     }
   }
 
   setPivot(pivot) {
-    vec3.transformQuat(this.#offset, this.#offset, quat.invert(this.#tmp_quat, this.#quatRot));
-    vec3.sub(this.#offset, this.#offset, this.#center);
+    vec3.transformQuat(this._offset, this._offset, quat.invert(this._tmp_quat, this._quatRot));
+    vec3.sub(this._offset, this._offset, this._center);
 
     // set new pivot
-    vec3.copy(this.#center, pivot);
-    vec3.add(this.#offset, this.#offset, this.#center);
-    vec3.transformQuat(this.#offset, this.#offset, this.#quatRot);
+    vec3.copy(this._center, pivot);
+    vec3.add(this._offset, this._offset, this._center);
+    vec3.transformQuat(this._offset, this._offset, this._quatRot);
 
     // adjust zoom
-    if (this.#projectionType === Enums.Projection.PERSPECTIVE) {
+    if (this._projectionType === Enums.Projection.PERSPECTIVE) {
       var oldZoom = this.getTransZ();
-      this.#trans[2] = vec3.dist(this.computePosition(), this.#center) * this.#fov / 45;
-      this.#offset[2] += this.getTransZ() - oldZoom;
+      this._trans[2] = vec3.dist(this.computePosition(), this._center) * this._fov / 45;
+      this._offset[2] += this.getTransZ() - oldZoom;
     } else {
-      this.#offset[2] = 0.0;
+      this._offset[2] = 0.0;
     }
   }
 
   /** Compute rotation values (by updating the quaternion) */
   rotate(mouseX, mouseY) {
-    var axisRot = this.#tmp_vec3;
-    var diff = this.#tmp_vec2;
+    var axisRot = this._tmp_vec3;
+    var diff = this._tmp_vec2;
 
-    var normalizedMouseXY = Geometry.normalizedMouse(mouseX, mouseY, this.#width, this.#height);
-    if (this.#mode === Enums.CameraMode.ORBIT) {
-      vec2.sub(diff, normalizedMouseXY, this.#lastNormalizedMouseXY);
-      this.setOrbit(this.#rotX - diff[1] * 2, this.#rotY + diff[0] * 2);
+    var normalizedMouseXY = Geometry.normalizedMouse(mouseX, mouseY, this._width, this._height);
+    if (this._mode === Enums.CameraMode.ORBIT) {
+      vec2.sub(diff, normalizedMouseXY, this._lastNormalizedMouseXY);
+      this.setOrbit(this._rotX - diff[1] * 2, this._rotY + diff[0] * 2);
 
       this.rotateDelay([-diff[1] * 6, diff[0] * 6], DELAY_ROTATE);
 
-    } else if (this.#mode === Enums.CameraMode.PLANE) {
-      var length = vec2.dist(this.#lastNormalizedMouseXY, normalizedMouseXY);
-      vec2.sub(diff, normalizedMouseXY, this.#lastNormalizedMouseXY);
+    } else if (this._mode === Enums.CameraMode.PLANE) {
+      var length = vec2.dist(this._lastNormalizedMouseXY, normalizedMouseXY);
+      vec2.sub(diff, normalizedMouseXY, this._lastNormalizedMouseXY);
       vec3.normalize(axisRot, vec3.set(axisRot, -diff[1], diff[0], 0.0));
-      quat.mul(this.#quatRot, quat.setAxisAngle(this.#tmp_quat, axisRot, length * 2.0), this.#quatRot);
+      quat.mul(this._quatRot, quat.setAxisAngle(this._tmp_quat, axisRot, length * 2.0), this._quatRot);
 
       this.rotateDelay([axisRot[0], axisRot[1], axisRot[2], length * 6], DELAY_ROTATE);
 
-    } else if (this.#mode === Enums.CameraMode.SPHERICAL) {
-      var mouseOnSphereBefore = Geometry.mouseOnUnitSphere(this.#lastNormalizedMouseXY);
+    } else if (this._mode === Enums.CameraMode.SPHERICAL) {
+      var mouseOnSphereBefore = Geometry.mouseOnUnitSphere(this._lastNormalizedMouseXY);
       var mouseOnSphereAfter = Geometry.mouseOnUnitSphere(normalizedMouseXY);
       var angle = Math.acos(Math.min(1.0, vec3.dot(mouseOnSphereBefore, mouseOnSphereAfter)));
       vec3.normalize(axisRot, vec3.cross(axisRot, mouseOnSphereBefore, mouseOnSphereAfter));
-      quat.mul(this.#quatRot, quat.setAxisAngle(this.#tmp_quat, axisRot, angle * 2.0), this.#quatRot);
+      quat.mul(this._quatRot, quat.setAxisAngle(this._tmp_quat, axisRot, angle * 2.0), this._quatRot);
 
       this.rotateDelay([axisRot[0], axisRot[1], axisRot[2], angle * 6], DELAY_ROTATE);
     }
 
-    this.#lastNormalizedMouseXY = normalizedMouseXY;
+    this._lastNormalizedMouseXY = normalizedMouseXY;
     this.updateView();
   }
 
   setOrbit(rx, ry) {
     var radLimit = Math.PI * 0.49;
-    this.#rotX = Math.max(Math.min(rx, radLimit), -radLimit);
-    this.#rotY = ry;
-    var qrt = this.#quatRot;
+    this._rotX = Math.max(Math.min(rx, radLimit), -radLimit);
+    this._rotY = ry;
+    var qrt = this._quatRot;
     quat.identity(qrt);
-    quat.rotateX(qrt, qrt, this.#rotX);
-    quat.rotateY(qrt, qrt, this.#rotY);
+    quat.rotateX(qrt, qrt, this._rotX);
+    quat.rotateY(qrt, qrt, this._rotY);
   }
 
   getTransZ() {
-    return this.#projectionType === Enums.Projection.PERSPECTIVE ? this.#trans[2] * 45 / this.#fov : 1000.0;
+    return this._projectionType === Enums.Projection.PERSPECTIVE ? this._trans[2] * 45 / this._fov : 1000.0;
   }
 
   updateView() {
-    var center = this.#tmp_vec3;
+    var center = this._tmp_vec3;
 
-    var view = this.#view;
-    var tx = this.#trans[0];
-    var ty = this.#trans[1];
+    var view = this._view;
+    var tx = this._trans[0];
+    var ty = this._trans[1];
 
-    var off = this.#offset;
-    vec3.set(this.#tmp_vec3_2, tx - off[0], ty - off[1], this.getTransZ() - off[2]);
+    var off = this._offset;
+    vec3.set(this._tmp_vec3_2, tx - off[0], ty - off[1], this.getTransZ() - off[2]);
     vec3.set(center, tx - off[0], ty - off[1], -off[2]);
-    mat4.lookAt(view, this.#tmp_vec3_2, center, UP);
+    mat4.lookAt(view, this._tmp_vec3_2, center, UP);
 
-    mat4.mul(view, view, mat4.fromQuat(this.#tmp_mat, this.#quatRot));
-    mat4.translate(view, view, vec3.negate(this.#tmp_vec3, this.#center));
+    mat4.mul(view, view, mat4.fromQuat(this._tmp_mat, this._quatRot));
+    mat4.translate(view, view, vec3.negate(this._tmp_vec3, this._center));
   }
 
   optimizeNearFar(bb?) {
-    if (!bb) bb = this.#lastBBox;
+    if (!bb) bb = this._lastBBox;
     if (!bb) return;
-    this.#lastBBox = bb;
+    this._lastBBox = bb;
 
-    var eye = this.computePosition(this.#tmp_vec3_2);
-    var boxCenter = vec3.set(this.#tmp_vec3, (bb[0] + bb[3]) * 0.5, (bb[1] + bb[4]) * 0.5, (bb[2] + bb[5]) * 0.5);
+    var eye = this.computePosition(this._tmp_vec3_2);
+    var boxCenter = vec3.set(this._tmp_vec3, (bb[0] + bb[3]) * 0.5, (bb[1] + bb[4]) * 0.5, (bb[2] + bb[5]) * 0.5);
     var distToBoxCenter = vec3.dist(eye, boxCenter);
 
-    var boxRadius = 0.5 * vec3.dist(bb, vec3.set(this.#tmp_vec3, bb[3], bb[4], bb[5]));
-    this.#near = Math.max(0.01, distToBoxCenter - boxRadius);
-    this.#far = boxRadius + distToBoxCenter;
+    var boxRadius = 0.5 * vec3.dist(bb, vec3.set(this._tmp_vec3, bb[3], bb[4], bb[5]));
+    this._near = Math.max(0.01, distToBoxCenter - boxRadius);
+    this._far = boxRadius + distToBoxCenter;
     this.updateProjection();
   }
 
   updateProjection() {
-    if (this.#projectionType === Enums.Projection.PERSPECTIVE) {
-      mat4.perspective(this.#proj, this.#fov * Math.PI / 180.0, this.#width / this.#height, this.#near, this.#far);
-      this.#proj[10] = -1.0;
-      this.#proj[14] = -2 * this.#near;
+    if (this._projectionType === Enums.Projection.PERSPECTIVE) {
+      mat4.perspective(this._proj, this._fov * Math.PI / 180.0, this._width / this._height, this._near, this._far);
+      this._proj[10] = -1.0;
+      this._proj[14] = -2 * this._near;
     } else {
       this.updateOrtho();
     }
   }
 
   updateTranslation() {
-    var trans = this.#trans;
-    trans[0] += this.#moveX * this.#speed * trans[2] / 50 / 400.0;
-    trans[2] = Math.max(0.00001, trans[2] + this.#moveZ * this.#speed / 400.0);
-    if (this.#projectionType === Enums.Projection.ORTHOGRAPHIC)
+    var trans = this._trans;
+    trans[0] += this._moveX * this._speed * trans[2] / 50 / 400.0;
+    trans[2] = Math.max(0.00001, trans[2] + this._moveZ * this._speed / 400.0);
+    if (this._projectionType === Enums.Projection.ORTHOGRAPHIC)
       this.updateOrtho();
     this.updateView();
   }
 
   translate(dx, dy) {
-    var factor = this.#speed * this.#trans[2] / 54;
+    var factor = this._speed * this._trans[2] / 54;
     var delta: vec3 = [-dx * factor, dy * factor, 0.0];
-    this.setTrans(vec3.add(this.#trans, this.#trans, delta));
+    this.setTrans(vec3.add(this._trans, this._trans, delta));
 
     vec3.scale(delta, delta, 5);
     this.translateDelay(delta, DELAY_TRANSLATE);
@@ -307,11 +307,11 @@ class Camera {
 
   zoom(df) {
     var delta: vec3 = [0.0, 0.0, 0.0];
-    vec3.sub(delta, this.#offset, this.#trans);
-    vec3.scale(delta, delta, df * this.#speed / 54);
+    vec3.sub(delta, this._offset, this._trans);
+    vec3.scale(delta, delta, df * this._speed / 54);
     if (df < 0.0)
       delta[0] = delta[1] = 0.0;
-    this.setTrans(vec3.add(this.#trans, this.#trans, delta));
+    this.setTrans(vec3.add(this._trans, this._trans, delta));
 
     vec3.scale(delta, delta, 5);
     this.translateDelay(delta, DELAY_TRANSLATE);
@@ -319,48 +319,48 @@ class Camera {
 
   setAndFocusOnPivot(pivot, zoom) {
     this.setPivot(pivot);
-    this.moveToDelay(this.#offset[0], this.#offset[1], this.#offset[2] + zoom);
+    this.moveToDelay(this._offset[0], this._offset[1], this._offset[2] + zoom);
   }
 
   moveToDelay(x, y, z) {
     var delta: vec3 = [x, y, z];
-    this.translateDelay(vec3.sub(delta, delta, this.#trans), DELAY_MOVE_TO);
+    this.translateDelay(vec3.sub(delta, delta, this._trans), DELAY_MOVE_TO);
   }
 
   setTrans(trans) {
-    vec3.copy(this.#trans, trans);
-    if (this.#projectionType === Enums.Projection.ORTHOGRAPHIC)
+    vec3.copy(this._trans, trans);
+    if (this._projectionType === Enums.Projection.ORTHOGRAPHIC)
       this.updateOrtho();
     this.updateView();
   }
 
   getOrthoZoom() {
-    return Math.abs(this.#trans[2]) * 0.00055;
+    return Math.abs(this._trans[2]) * 0.00055;
   }
 
   updateOrtho() {
     var delta = this.getOrthoZoom();
-    var w = this.#width * delta;
-    var h = this.#height * delta;
-    mat4.ortho(this.#proj, -w, w, -h, h, -this.#near, this.#far);
+    var w = this._width * delta;
+    var h = this._height * delta;
+    mat4.ortho(this._proj, -w, w, -h, h, -this._near, this._far);
   }
 
   computePosition(out: vec3 = [0, 0, 0]) {
 
-    var view = this.#view;
+    var view = this._view;
     vec3.set(out, -view[12], -view[13], -view[14]);
 
-    mat3.fromMat4(<mat3><unknown>this.#tmp_mat, view);
-    mat3.transpose(<mat3><unknown>this.#tmp_mat, <mat3><unknown>this.#tmp_mat);
-    return vec3.transformMat3(out, out, <mat3><unknown>this.#tmp_mat);
+    mat3.fromMat4(<mat3><unknown>this._tmp_mat, view);
+    mat3.transpose(<mat3><unknown>this._tmp_mat, <mat3><unknown>this._tmp_mat);
+    return vec3.transformMat3(out, out, <mat3><unknown>this._tmp_mat);
   }
 
   resetView() {
-    this.#speed = Utils.SCALE * 1.5;
+    this._speed = Utils.SCALE * 1.5;
     this.centerDelay([0.0, 0.0, 0.0], DELAY_MOVE_TO);
     this.offsetDelay([0.0, 0.0, 0.0], DELAY_MOVE_TO);
-    var delta: vec3 = [0.0, 0.0, 30.0 + this.#speed / 3.0];
-    vec3.sub(delta, delta, this.#trans);
+    var delta: vec3 = [0.0, 0.0, 30.0 + this._speed / 3.0];
+    vec3.sub(delta, delta, this._trans);
     this.translateDelay(delta, DELAY_MOVE_TO);
     this.quatDelay([0.0, 0.0, 0.0, 1.0], DELAY_MOVE_TO);
   }
@@ -390,56 +390,56 @@ class Camera {
   }
 
   toggleViewFront() {
-    if (Math.abs(this.#quatRot[3]) > 0.99) this.resetViewBack();
+    if (Math.abs(this._quatRot[3]) > 0.99) this.resetViewBack();
     else this.resetViewFront();
   }
 
   toggleViewTop() {
-    var dot = this.#quatRot[0] * Math.SQRT1_2 + this.#quatRot[3] * Math.SQRT1_2;
+    var dot = this._quatRot[0] * Math.SQRT1_2 + this._quatRot[3] * Math.SQRT1_2;
     if (dot * dot > 0.99) this.resetViewBottom();
     else this.resetViewTop();
   }
 
   toggleViewLeft() {
-    var dot = -this.#quatRot[1] * Math.SQRT1_2 + this.#quatRot[3] * Math.SQRT1_2;
+    var dot = -this._quatRot[1] * Math.SQRT1_2 + this._quatRot[3] * Math.SQRT1_2;
     if (dot * dot > 0.99) this.resetViewRight();
     else this.resetViewLeft();
   }
 
   computeWorldToScreenMatrix(mat) {
     mat = mat || mat4.create();
-    return mat4.mul(mat, mat4.mul(mat, this.#viewport, this.#proj), this.#view);
+    return mat4.mul(mat, mat4.mul(mat, this._viewport, this._proj), this._view);
   }
 
   /** Project the mouse coordinate into the world coordinate at a given z */
   unproject(mouseX, mouseY, z) {
     var out: vec3 = [0.0, 0.0, 0.0];
-    mat4.invert(this.#tmp_mat, this.computeWorldToScreenMatrix(this.#tmp_mat));
-    return vec3.transformMat4(out, vec3.set(out, mouseX, this.#height - mouseY, z), this.#tmp_mat);
+    mat4.invert(this._tmp_mat, this.computeWorldToScreenMatrix(this._tmp_mat));
+    return vec3.transformMat4(out, vec3.set(out, mouseX, this._height - mouseY, z), this._tmp_mat);
   }
 
   /** Project a vertex onto the screen */
   project(vector) {
     var out: vec3 = [0.0, 0.0, 0.0];
-    vec3.transformMat4(out, vector, this.computeWorldToScreenMatrix(this.#tmp_mat));
-    out[1] = this.#height - out[1];
+    vec3.transformMat4(out, vector, this.computeWorldToScreenMatrix(this._tmp_mat));
+    out[1] = this._height - out[1];
     return out;
   }
 
   onResize(width, height) {
-    this.#width = width;
-    this.#height = height;
+    this._width = width;
+    this._height = height;
 
-    var vp = this.#viewport;
+    var vp = this._viewport;
     mat4.identity(vp);
-    mat4.scale(vp, vp, vec3.set(this.#tmp_vec3, 0.5 * width, 0.5 * height, 0.5));
-    mat4.translate(vp, vp, vec3.set(this.#tmp_vec3, 1.0, 1.0, 1.0));
+    mat4.scale(vp, vp, vec3.set(this._tmp_vec3, 0.5 * width, 0.5 * height, 0.5));
+    mat4.translate(vp, vp, vec3.set(this._tmp_vec3, 1.0, 1.0, 1.0));
 
     this.updateProjection();
   }
 
   snapClosestRotation() {
-    var qrot = this.#quatRot;
+    var qrot = this._quatRot;
     var min = Infinity;
     var id = 0;
     var nbQComp = _QUAT_COMP.length;
@@ -455,13 +455,13 @@ class Camera {
   }
 
   clearTimerN(n) {
-    window.clearInterval(this.#timers[n]);
-    this.#timers[n] = 0;
+    window.clearInterval(this._timers[n]);
+    this._timers[n] = 0;
   }
 
   delay(cb, duration, name) {
     var nTimer = name || 'default';
-    if (this.#timers[nTimer])
+    if (this._timers[nTimer])
       this.clearTimerN(nTimer);
 
     if (duration === 0.0)
@@ -471,7 +471,7 @@ class Camera {
 
     var lastR = 0;
     var tStart = (new Date()).getTime();
-    this.#timers[nTimer] = window.setInterval(function () {
+    this._timers[nTimer] = window.setInterval(function () {
       var r = ((new Date()).getTime() - tStart) / duration;
       r = easeOutQuart(r);
       cb(r - lastR, r);
@@ -482,10 +482,10 @@ class Camera {
   }
 
   private _translateDelta(delta, dr) {
-    var trans = this.#trans;
+    var trans = this._trans;
     vec3.scaleAndAdd(trans, trans, delta, dr);
     this.setTrans(trans);
-    this.#main.render();
+    this._main.render();
   }
 
   translateDelay(delta, duration) {
@@ -494,15 +494,15 @@ class Camera {
   }
 
   private _rotDelta(delta, dr) {
-    if (this.#mode === Enums.CameraMode.ORBIT) {
-      var rx = this.#rotX + delta[0] * dr;
-      var ry = this.#rotY + delta[1] * dr;
+    if (this._mode === Enums.CameraMode.ORBIT) {
+      var rx = this._rotX + delta[0] * dr;
+      var ry = this._rotY + delta[1] * dr;
       this.setOrbit(rx, ry);
     } else {
-      quat.mul(this.#quatRot, quat.setAxisAngle(this.#tmp_quat, delta, delta[3] * dr), this.#quatRot);
+      quat.mul(this._quatRot, quat.setAxisAngle(this._tmp_quat, delta, delta[3] * dr), this._quatRot);
     }
     this.updateView();
-    this.#main.render();
+    this._main.render();
   }
 
   rotateDelay(delta, duration) {
@@ -511,28 +511,28 @@ class Camera {
   }
 
   private _quatDelta(qDelta, dr) {
-    quat.identity(this.#tmp_quat);
-    quat.slerp(this.#tmp_quat, this.#tmp_quat, qDelta, dr);
-    var qrt = this.#quatRot;
-    quat.mul(this.#quatRot, this.#quatRot, this.#tmp_quat);
+    quat.identity(this._tmp_quat);
+    quat.slerp(this._tmp_quat, this._tmp_quat, qDelta, dr);
+    var qrt = this._quatRot;
+    quat.mul(this._quatRot, this._quatRot, this._tmp_quat);
 
-    if (this.#mode === Enums.CameraMode.ORBIT) {
+    if (this._mode === Enums.CameraMode.ORBIT) {
       var qx = qrt[0];
       var qy = qrt[1];
       var qz = qrt[2];
       var qw = qrt[3];
       // find back euler values
-      this.#rotY = Math.atan2(2 * (qw * qy + qz * qx), 1 - 2 * (qy * qy + qz * qz));
-      this.#rotX = Math.atan2(2 * (qw * qx + qy * qz), 1 - 2 * (qz * qz + qx * qx));
+      this._rotY = Math.atan2(2 * (qw * qy + qz * qx), 1 - 2 * (qy * qy + qz * qz));
+      this._rotX = Math.atan2(2 * (qw * qx + qy * qz), 1 - 2 * (qz * qz + qx * qx));
     }
 
     this.updateView();
-    this.#main.render();
+    this._main.render();
   }
 
   quatDelay(target, duration) {
     var qDelta: quat = [0.0, 0.0, 0.0, 0.0];
-    quat.conjugate(qDelta, this.#quatRot);
+    quat.conjugate(qDelta, this._quatRot);
     quat.mul(qDelta, qDelta, target);
     quat.normalize(qDelta, qDelta);
 
@@ -541,41 +541,41 @@ class Camera {
   }
 
   private _centerDelta(delta, dr) {
-    vec3.scaleAndAdd(this.#center, this.#center, delta, dr);
+    vec3.scaleAndAdd(this._center, this._center, delta, dr);
     this.updateView();
-    this.#main.render();
+    this._main.render();
   }
 
   centerDelay(target, duration) {
     var delta: vec3 = [0.0, 0.0, 0.0];
-    vec3.sub(delta, target, this.#center);
+    vec3.sub(delta, target, this._center);
     var cb = this._centerDelta.bind(this, delta);
     this.delay(cb, duration, 'center');
   }
 
   private _offsetDelta(delta, dr) {
-    vec3.scaleAndAdd(this.#offset, this.#offset, delta, dr);
+    vec3.scaleAndAdd(this._offset, this._offset, delta, dr);
     this.updateView();
-    this.#main.render();
+    this._main.render();
   }
 
   offsetDelay(target, duration) {
     var delta: vec3 = [0.0, 0.0, 0.0];
-    vec3.sub(delta, target, this.#offset);
+    vec3.sub(delta, target, this._offset);
     var cb = this._offsetDelta.bind(this, delta);
     this.delay(cb, duration, 'offset');
   }
 
   computeFrustumFit() {
-    var near = this.#near;
+    var near = this._near;
     var x;
 
-    if (this.#projectionType === Enums.Projection.ORTHOGRAPHIC) {
-      x = Math.min(this.#width, this.#height) / near * 0.5;
+    if (this._projectionType === Enums.Projection.ORTHOGRAPHIC) {
+      x = Math.min(this._width, this._height) / near * 0.5;
       return Math.sqrt(1.0 + x * x) / x;
     }
 
-    var proj = this.#proj;
+    var proj = this._proj;
     var left = near * (proj[8] - 1.0) / proj[0];
     var right = near * (1.0 + proj[8]) / proj[0];
     var top = near * (1.0 + proj[9]) / proj[5];
@@ -584,7 +584,7 @@ class Camera {
     var horizontal2 = Math.abs(top - bottom);
 
     x = Math.min(horizontal2, vertical2) / near * 0.5;
-    return (this.#fov / 45.0) * Math.sqrt(1.0 + x * x) / x;
+    return (this._fov / 45.0) * Math.sqrt(1.0 + x * x) / x;
   }
 }
 

--- a/src/math3d/OctreeCell.ts
+++ b/src/math3d/OctreeCell.ts
@@ -1,17 +1,17 @@
 class OctreeCell {
 
-  #parent: OctreeCell | null;  // parent
-  #depth: number; // depth of current node
-  #children: OctreeCell[] = []; // children
+  _parent: OctreeCell | null;  // parent
+  _depth: number; // depth of current node
+  _children: OctreeCell[] = []; // children
 
   // extended boundary for intersect test
-  #aabbLoose: number[] = [Infinity, Infinity, Infinity, -Infinity, -Infinity, -Infinity];
+  _aabbLoose: number[] = [Infinity, Infinity, Infinity, -Infinity, -Infinity, -Infinity];
 
   // boundary in order to store exactly the face according to their center
-  #aabbSplit: number[] = [Infinity, Infinity, Infinity, -Infinity, -Infinity, -Infinity];
-  #iFaces: number[] = []; // faces (if cell is a leaf)
+  _aabbSplit: number[] = [Infinity, Infinity, Infinity, -Infinity, -Infinity, -Infinity];
+  _iFaces: number[] = []; // faces (if cell is a leaf)
 
-  #flag = 0; // to track deleted cell
+  _flag = 0; // to track deleted cell
 
   static FLAG: number;
   static STACK: OctreeCell[];
@@ -27,28 +27,28 @@ class OctreeCell {
   }
 
   constructor(parent: OctreeCell | null = null) {
-    this.#parent = parent ? parent : null; // parent
-    this.#depth = parent != null ? parent.#depth + 1 : 0; // depth of current node
+    this._parent = parent ? parent : null; // parent
+    this._depth = parent != null ? parent._depth + 1 : 0; // depth of current node
   }
 
   get aabbLoose() {
-    return this.#aabbLoose;
+    return this._aabbLoose;
   }
 
   get iFaces() {
-    return this.#iFaces;
+    return this._iFaces;
   }
 
   get aabbSplit() {
-    return this.#aabbSplit;
+    return this._aabbSplit;
   }
 
   get depth() {
-    return this.#depth
+    return this._depth
   }
 
   resetNbFaces(nbFaces) {
-    var facesAll = this.#iFaces;
+    var facesAll = this._iFaces;
     facesAll.length = nbFaces;
     for (var i = 0; i < nbFaces; ++i)
       facesAll[i] = i;
@@ -64,10 +64,10 @@ class OctreeCell {
     var leaves: OctreeCell[] = [];
     while (curStack > 0) {
       var cell = stack[--curStack];
-      var nbFaces = cell.#iFaces.length;
-      if (nbFaces > OctreeCell.MAX_FACES && cell.#depth < OctreeCell.MAX_DEPTH) {
+      var nbFaces = cell._iFaces.length;
+      if (nbFaces > OctreeCell.MAX_FACES && cell._depth < OctreeCell.MAX_DEPTH) {
         cell.constructChildren(mesh);
-        var children = cell.#children;
+        var children = cell._children;
         for (i = 0; i < 8; ++i)
           stack[curStack + i] = children[i];
         curStack += 8;
@@ -83,7 +83,7 @@ class OctreeCell {
 
   /** Construct the leaf  */
   constructLeaf(mesh) {
-    var iFaces = this.#iFaces;
+    var iFaces = this._iFaces;
     var nbFaces = iFaces.length;
     var bxmin = Infinity;
     var bymin = Infinity;
@@ -117,7 +117,7 @@ class OctreeCell {
 
   /** Construct sub cells of the octree */
   constructChildren(mesh) {
-    var split = this.#aabbSplit;
+    var split = this._aabbSplit;
     var xmin = split[0];
     var ymin = split[1];
     var zmin = split[2];
@@ -140,16 +140,16 @@ class OctreeCell {
     var child6 = new OctreeCell(this);
     var child7 = new OctreeCell(this);
 
-    var iFaces0 = child0.#iFaces;
-    var iFaces1 = child1.#iFaces;
-    var iFaces2 = child2.#iFaces;
-    var iFaces3 = child3.#iFaces;
-    var iFaces4 = child4.#iFaces;
-    var iFaces5 = child5.#iFaces;
-    var iFaces6 = child6.#iFaces;
-    var iFaces7 = child7.#iFaces;
+    var iFaces0 = child0._iFaces;
+    var iFaces1 = child1._iFaces;
+    var iFaces2 = child2._iFaces;
+    var iFaces3 = child3._iFaces;
+    var iFaces4 = child4._iFaces;
+    var iFaces5 = child5._iFaces;
+    var iFaces6 = child6._iFaces;
+    var iFaces7 = child7._iFaces;
     var faceCenters = mesh.getFaceCenters();
-    var iFaces = this.#iFaces;
+    var iFaces = this._iFaces;
     var nbFaces = iFaces.length;
     for (var i = 0; i < nbFaces; ++i) {
       var iFace = iFaces[i];
@@ -186,13 +186,13 @@ class OctreeCell {
     child6.setAabbSplit(xcen, ycen, zcen, xmax, ymax, zmax);
     child7.setAabbSplit(xcen - dX, ycen, zcen, xmax - dX, ymax, zmax);
 
-    this.#children.length = 0;
-    this.#children.push(child0, child1, child2, child3, child4, child5, child6, child7);
+    this._children.length = 0;
+    this._children.push(child0, child1, child2, child3, child4, child5, child6, child7);
     iFaces.length = 0;
   }
 
   setAabbSplit(xmin, ymin, zmin, xmax, ymax, zmax) {
-    var aabb = this.#aabbSplit;
+    var aabb = this._aabbSplit;
     aabb[0] = xmin;
     aabb[1] = ymin;
     aabb[2] = zmin;
@@ -202,7 +202,7 @@ class OctreeCell {
   }
 
   setAabbLoose(xmin, ymin, zmin, xmax, ymax, zmax) {
-    var aabb = this.#aabbLoose;
+    var aabb = this._aabbLoose;
     aabb[0] = xmin;
     aabb[1] = ymin;
     aabb[2] = zmin;
@@ -226,7 +226,7 @@ class OctreeCell {
     var curStack = 1;
     while (curStack > 0) {
       var cell = stack[--curStack];
-      var loose = cell.#aabbLoose;
+      var loose = cell._aabbLoose;
       var t1 = (loose[0] - vx) * irx;
       var t2 = (loose[3] - vx) * irx;
       var t3 = (loose[1] - vy) * iry;
@@ -238,14 +238,14 @@ class OctreeCell {
       if (tmax < 0 || tmin > tmax) // no intersection
         continue;
 
-      var children = cell.#children;
+      var children = cell._children;
       if (children.length === 8) {
         for (var i = 0; i < 8; ++i)
           stack[curStack + i] = children[i];
         curStack += 8;
       } else {
         if (leavesHit) leavesHit.push(cell);
-        var iFaces = cell.#iFaces;
+        var iFaces = cell._iFaces;
         collectFaces.set(iFaces, acc);
         acc += iFaces.length;
       }
@@ -265,7 +265,7 @@ class OctreeCell {
     var curStack = 1;
     while (curStack > 0) {
       var cell = stack[--curStack];
-      var loose = cell.#aabbLoose;
+      var loose = cell._aabbLoose;
       var dx = 0.0;
       var dy = 0.0;
       var dz = 0.0;
@@ -285,14 +285,14 @@ class OctreeCell {
       if ((dx * dx + dy * dy + dz * dz) > radiusSquared) // no intersection
         continue;
 
-      var children = cell.#children;
+      var children = cell._children;
       if (children.length === 8) {
         for (var i = 0; i < 8; ++i)
           stack[curStack + i] = children[i];
         curStack += 8;
       } else {
         if (leavesHit) leavesHit.push(cell);
-        var iFaces = cell.#iFaces;
+        var iFaces = cell._iFaces;
         collectFaces.set(iFaces, acc);
         acc += iFaces.length;
       }
@@ -307,7 +307,7 @@ class OctreeCell {
     var curStack = 1;
     while (curStack > 0) {
       var cell = stack[--curStack];
-      var split = cell.#aabbSplit;
+      var split = cell._aabbSplit;
       if (cx <= split[0]) continue;
       if (cy <= split[1]) continue;
       if (cz <= split[2]) continue;
@@ -315,7 +315,7 @@ class OctreeCell {
       if (cy > split[4]) continue;
       if (cz > split[5]) continue;
 
-      var loose = cell.#aabbLoose;
+      var loose = cell._aabbLoose;
       // expands cell aabb loose with aabb face
       if (bxmin < loose[0]) loose[0] = bxmin;
       if (bymin < loose[1]) loose[1] = bymin;
@@ -323,14 +323,14 @@ class OctreeCell {
       if (bxmax > loose[3]) loose[3] = bxmax;
       if (bymax > loose[4]) loose[4] = bymax;
       if (bzmax > loose[5]) loose[5] = bzmax;
-      var children = cell.#children;
+      var children = cell._children;
 
       if (children.length === 8) {
         for (var i = 0; i < 8; ++i)
           stack[curStack + i] = children[i];
         curStack += 8;
       } else {
-        cell.#iFaces.push(faceId);
+        cell._iFaces.push(faceId);
         return cell;
       }
     }
@@ -339,10 +339,10 @@ class OctreeCell {
   /** Cut leaves if needed */
   pruneIfPossible() {
     var cell: OctreeCell = this;
-    while (cell.#parent) {
-      var parent = cell.#parent;
+    while (cell._parent) {
+      var parent = cell._parent;
 
-      var children = parent.#children;
+      var children = parent._children;
       // means that the current cell has already pruned
       if (children.length === 0)
         return;
@@ -350,7 +350,7 @@ class OctreeCell {
       // check if we can prune
       for (var i = 0; i < 8; ++i) {
         var child = children[i];
-        if (child.#iFaces.length > 0 || child.#children.length === 8) {
+        if (child._iFaces.length > 0 || child._children.length === 8) {
           return;
         }
       }
@@ -364,7 +364,7 @@ class OctreeCell {
   expandsAabbLoose(bxmin, bymin, bzmin, bxmax, bymax, bzmax) {
     var parent: OctreeCell | null = this;
     while (parent) {
-      var pLoose = parent.#aabbLoose;
+      var pLoose = parent._aabbLoose;
       var proceed = false;
       if (bxmin < pLoose[0]) {
         pLoose[0] = bxmin;
@@ -390,7 +390,7 @@ class OctreeCell {
         pLoose[5] = bzmax;
         proceed = true;
       }
-      parent = proceed ? parent.#parent : null;
+      parent = proceed ? parent._parent : null;
     }
   }
 }

--- a/src/math3d/Picking.ts
+++ b/src/math3d/Picking.ts
@@ -15,34 +15,34 @@ const HARDCODED_ALPHAS: { [k: string]: any } = {
 
 class Picking {
 
-  #mesh: any; // mesh
-  #main: any; // the camera
-  #pickedFace = -1; // face picked
-  #pickedVertices: Uint32Array; // vertices selected
-  #interPoint: vec3 = [0.0, 0.0, 0.0]; // intersection point (mesh local space)
-  #rLocal2 = 0.0; // radius of the selection area (local/object space)
-  #rWorld2 = 0.0; // radius of the selection area (world space)
-  #eyeDir: vec3 = [0.0, 0.0, 0.0]; // eye direction
+  _mesh: any; // mesh
+  _main: any; // the camera
+  _pickedFace = -1; // face picked
+  _pickedVertices: Uint32Array; // vertices selected
+  _interPoint: vec3 = [0.0, 0.0, 0.0]; // intersection point (mesh local space)
+  _rLocal2 = 0.0; // radius of the selection area (local/object space)
+  _rWorld2 = 0.0; // radius of the selection area (world space)
+  _eyeDir: vec3 = [0.0, 0.0, 0.0]; // eye direction
 
-  #xSym: boolean
+  _xSym: boolean
 
-  #pickedNormal: vec3 = [0.0, 0.0, 0.0];
+  _pickedNormal: vec3 = [0.0, 0.0, 0.0];
   // alpha stuffs
-  #alphaOrigin: vec3 = [0.0, 0.0, 0.0];
-  #alphaSide = 0.0;
-  #alphaLookAt: mat4 = mat4.create();
-  #alpha: { [k: string]: any };
+  _alphaOrigin: vec3 = [0.0, 0.0, 0.0];
+  _alphaSide = 0.0;
+  _alphaLookAt: mat4 = mat4.create();
+  _alpha: { [k: string]: any };
 
   // Scratch vars to reduce allocations
-  #tmpNear: vec3 = [0.0, 0.0, 0.0];
-  #tmpNear1: vec3 = [0.0, 0.0, 0.0];
-  #tmpFar: vec3 = [0.0, 0.0, 0.0];
-  #tmpInv: mat4 = mat4.create();
-  #tmpInter: vec3 = [0.0, 0.0, 0.0];
-  #tmpInter1: vec3 = [0.0, 0.0, 0.0];
-  #tmpV1: vec3 = [0.0, 0.0, 0.0];
-  #tmpV2: vec3 = [0.0, 0.0, 0.0];
-  #tmpV3: vec3 = [0.0, 0.0, 0.0];
+  _tmpNear: vec3 = [0.0, 0.0, 0.0];
+  _tmpNear1: vec3 = [0.0, 0.0, 0.0];
+  _tmpFar: vec3 = [0.0, 0.0, 0.0];
+  _tmpInv: mat4 = mat4.create();
+  _tmpInter: vec3 = [0.0, 0.0, 0.0];
+  _tmpInter1: vec3 = [0.0, 0.0, 0.0];
+  _tmpV1: vec3 = [0.0, 0.0, 0.0];
+  _tmpV2: vec3 = [0.0, 0.0, 0.0];
+  _tmpV3: vec3 = [0.0, 0.0, 0.0];
 
   static ALPHAS: { [k: string]: any } = {};
   static ALPHAS_NAMES: { [k: string]: string } = {};
@@ -118,22 +118,22 @@ class Picking {
   }
 
   constructor(main, xSym) {
-    this.#main = main; // the camera
-    this.#xSym = !!xSym;
+    this._main = main; // the camera
+    this._xSym = !!xSym;
   }
 
   setIdAlpha(id) {
-    this.#alpha = Picking.ALPHAS[id];
+    this._alpha = Picking.ALPHAS[id];
   }
 
   getAlpha(x, y, z) {
-    var alpha = this.#alpha;
+    var alpha = this._alpha;
     if (!alpha || !alpha._texture) return 1.0;
 
-    var m = this.#alphaLookAt;
-    var rs = this.#alphaSide;
+    var m = this._alphaLookAt;
+    var rs = this._alphaSide;
 
-    var xn = alpha._ratioY * (m[0] * x + m[4] * y + m[8] * z + m[12]) / (this.#xSym ? -rs : rs);
+    var xn = alpha._ratioY * (m[0] * x + m[4] * y + m[8] * z + m[12]) / (this._xSym ? -rs : rs);
     if (Math.abs(xn) > 1.0) return 0.0;
 
     var yn = alpha._ratioX * (m[1] * x + m[5] * y + m[9] * z + m[13]) / rs;
@@ -146,25 +146,25 @@ class Picking {
   }
 
   updateAlpha(keepOrigin = false) {
-    var dir = this.#tmpV1;
-    var nor = this.#tmpV2;
+    var dir = this._tmpV1;
+    var nor = this._tmpV2;
 
-    var radius = Math.sqrt(this.#rLocal2);
-    this.#alphaSide = radius * Math.SQRT1_2;
+    var radius = Math.sqrt(this._rLocal2);
+    this._alphaSide = radius * Math.SQRT1_2;
 
-    vec3.sub(dir, this.#interPoint, this.#alphaOrigin);
+    vec3.sub(dir, this._interPoint, this._alphaOrigin);
     if (vec3.len(dir) === 0) return;
     vec3.normalize(dir, dir);
 
-    var normal = this.#pickedNormal;
+    var normal = this._pickedNormal;
     vec3.scaleAndAdd(dir, dir, normal, -vec3.dot(dir, normal));
     vec3.normalize(dir, dir);
 
     if (!keepOrigin)
-      vec3.copy(this.#alphaOrigin, this.#interPoint);
+      vec3.copy(this._alphaOrigin, this._interPoint);
 
-    vec3.scaleAndAdd(nor, this.#alphaOrigin, normal, radius);
-    mat4.lookAt(this.#alphaLookAt, this.#alphaOrigin, nor, dir);
+    vec3.scaleAndAdd(nor, this._alphaOrigin, normal, radius);
+    mat4.lookAt(this._alphaLookAt, this._alphaOrigin, nor, dir);
   }
 
   initAlpha() {
@@ -173,55 +173,55 @@ class Picking {
   }
 
   getMesh() {
-    return this.#mesh;
+    return this._mesh;
   }
 
   setLocalRadius2(radius) {
-    this.#rLocal2 = radius;
+    this._rLocal2 = radius;
   }
 
   getLocalRadius2() {
-    return this.#rLocal2;
+    return this._rLocal2;
   }
 
   getLocalRadius() {
-    return Math.sqrt(this.#rLocal2);
+    return Math.sqrt(this._rLocal2);
   }
 
   getWorldRadius2() {
-    return this.#rWorld2;
+    return this._rWorld2;
   }
 
   getWorldRadius() {
-    return Math.sqrt(this.#rWorld2);
+    return Math.sqrt(this._rWorld2);
   }
 
   setIntersectionPoint(inter) {
-    this.#interPoint = inter;
+    this._interPoint = inter;
   }
 
   getEyeDirection() {
-    return this.#eyeDir;
+    return this._eyeDir;
   }
 
   getIntersectionPoint() {
-    return this.#interPoint;
+    return this._interPoint;
   }
 
   getPickedVertices() {
-    return this.#pickedVertices;
+    return this._pickedVertices;
   }
 
   getPickedFace() {
-    return this.#pickedFace;
+    return this._pickedFace;
   }
 
   getPickedNormal() {
-    return this.#pickedNormal;
+    return this._pickedNormal;
   }
 
   /** Intersection between a ray the mouse position for every meshes */
-  intersectionMouseMeshes(meshes = this.#main.getMeshes(), mouseX = this.#main._mouseX, mouseY = this.#main._mouseY) {
+  intersectionMouseMeshes(meshes = this._main.getMeshes(), mouseX = this._main._mouseX, mouseY = this._main._mouseY) {
 
     var vNear = this.unproject(mouseX, mouseY, 0.0);
     var vFar = this.unproject(mouseX, mouseY, 0.1);
@@ -234,32 +234,32 @@ class Picking {
       if (!mesh.isVisible())
         continue;
 
-      mat4.invert(this.#tmpInv, mesh.getMatrix());
-      vec3.transformMat4(this.#tmpNear1, vNear, this.#tmpInv);
-      vec3.transformMat4(this.#tmpFar, vFar, this.#tmpInv);
-      if (!this.intersectionRayMesh(mesh, this.#tmpNear1, this.#tmpFar))
+      mat4.invert(this._tmpInv, mesh.getMatrix());
+      vec3.transformMat4(this._tmpNear1, vNear, this._tmpInv);
+      vec3.transformMat4(this._tmpFar, vFar, this._tmpInv);
+      if (!this.intersectionRayMesh(mesh, this._tmpNear1, this._tmpFar))
         continue;
 
       var interTest = this.getIntersectionPoint();
-      var testDistance = vec3.dist(this.#tmpNear1, interTest) * mesh.getScale();
+      var testDistance = vec3.dist(this._tmpNear1, interTest) * mesh.getScale();
       if (testDistance < nearDistance) {
         nearDistance = testDistance;
         nearMesh = mesh;
-        vec3.copy(this.#tmpInter1, interTest);
+        vec3.copy(this._tmpInter1, interTest);
         nearFace = this.getPickedFace();
       }
     }
 
-    this.#mesh = nearMesh;
-    vec3.copy(this.#interPoint, this.#tmpInter1);
-    this.#pickedFace = nearFace;
+    this._mesh = nearMesh;
+    vec3.copy(this._interPoint, this._tmpInter1);
+    this._pickedFace = nearFace;
     if (nearFace !== -1)
       this.updateLocalAndWorldRadius2();
     return !!nearMesh;
   }
 
   /** Intersection between a ray the mouse position */
-  intersectionMouseMesh(mesh = this.#main.getMesh(), mouseX = this.#main._mouseX, mouseY = this.#main._mouseY) {
+  intersectionMouseMesh(mesh = this._main.getMesh(), mouseX = this._main._mouseX, mouseY = this._main._mouseY) {
     var vNear = this.unproject(mouseX, mouseY, 0.0);
     var vFar = this.unproject(mouseX, mouseY, 0.1);
     var matInverse = mat4.create();
@@ -272,25 +272,25 @@ class Picking {
   /** Intersection between a ray and a mesh */
   intersectionRayMesh(mesh, vNearOrig, vFarOrig) {
     // resest picking
-    this.#mesh = null;
-    this.#pickedFace = -1;
+    this._mesh = null;
+    this._pickedFace = -1;
     // resest picking
-    vec3.copy(this.#tmpNear, vNearOrig);
-    vec3.copy(this.#tmpFar, vFarOrig);
+    vec3.copy(this._tmpNear, vNearOrig);
+    vec3.copy(this._tmpFar, vFarOrig);
     // apply symmetry
-    if (this.#xSym) {
+    if (this._xSym) {
       var ptPlane = mesh.getSymmetryOrigin();
       var nPlane = mesh.getSymmetryNormal();
-      Geometry.mirrorPoint(this.#tmpNear, ptPlane, nPlane);
-      Geometry.mirrorPoint(this.#tmpFar, ptPlane, nPlane);
+      Geometry.mirrorPoint(this._tmpNear, ptPlane, nPlane);
+      Geometry.mirrorPoint(this._tmpFar, ptPlane, nPlane);
     }
     var vAr = mesh.getVertices();
     var fAr = mesh.getFaces();
     // compute eye direction
     var eyeDir = this.getEyeDirection();
-    vec3.sub(eyeDir, this.#tmpFar, this.#tmpNear);
+    vec3.sub(eyeDir, this._tmpFar, this._tmpNear);
     vec3.normalize(eyeDir, eyeDir);
-    var iFacesCandidates = mesh.intersectRay(this.#tmpNear, eyeDir);
+    var iFacesCandidates = mesh.intersectRay(this._tmpNear, eyeDir);
     var distance = Infinity;
     var nbFacesCandidates = iFacesCandidates.length;
     for (var i = 0; i < nbFacesCandidates; ++i) {
@@ -298,44 +298,44 @@ class Picking {
       var ind1 = fAr[indFace] * 3;
       var ind2 = fAr[indFace + 1] * 3;
       var ind3 = fAr[indFace + 2] * 3;
-      this.#tmpV1[0] = vAr[ind1];
-      this.#tmpV1[1] = vAr[ind1 + 1];
-      this.#tmpV1[2] = vAr[ind1 + 2];
-      this.#tmpV2[0] = vAr[ind2];
-      this.#tmpV2[1] = vAr[ind2 + 1];
-      this.#tmpV2[2] = vAr[ind2 + 2];
-      this.#tmpV3[0] = vAr[ind3];
-      this.#tmpV3[1] = vAr[ind3 + 1];
-      this.#tmpV3[2] = vAr[ind3 + 2];
-      var hitDist = Geometry.intersectionRayTriangle(this.#tmpNear, eyeDir, this.#tmpV1, this.#tmpV2, this.#tmpV3, this.#tmpInter);
+      this._tmpV1[0] = vAr[ind1];
+      this._tmpV1[1] = vAr[ind1 + 1];
+      this._tmpV1[2] = vAr[ind1 + 2];
+      this._tmpV2[0] = vAr[ind2];
+      this._tmpV2[1] = vAr[ind2 + 1];
+      this._tmpV2[2] = vAr[ind2 + 2];
+      this._tmpV3[0] = vAr[ind3];
+      this._tmpV3[1] = vAr[ind3 + 1];
+      this._tmpV3[2] = vAr[ind3 + 2];
+      var hitDist = Geometry.intersectionRayTriangle(this._tmpNear, eyeDir, this._tmpV1, this._tmpV2, this._tmpV3, this._tmpInter);
       if (hitDist < 0.0) {
         ind2 = fAr[indFace + 3];
         if (ind2 !== Utils.TRI_INDEX) {
           ind2 *= 3;
-          this.#tmpV2[0] = vAr[ind2];
-          this.#tmpV2[1] = vAr[ind2 + 1];
-          this.#tmpV2[2] = vAr[ind2 + 2];
-          hitDist = Geometry.intersectionRayTriangle(this.#tmpNear, eyeDir, this.#tmpV1, this.#tmpV3, this.#tmpV2, this.#tmpInter);
+          this._tmpV2[0] = vAr[ind2];
+          this._tmpV2[1] = vAr[ind2 + 1];
+          this._tmpV2[2] = vAr[ind2 + 2];
+          hitDist = Geometry.intersectionRayTriangle(this._tmpNear, eyeDir, this._tmpV1, this._tmpV3, this._tmpV2, this._tmpInter);
         }
       }
       if (hitDist >= 0.0 && hitDist < distance) {
         distance = hitDist;
-        vec3.copy(this.#interPoint, this.#tmpInter);
-        this.#pickedFace = iFacesCandidates[i];
+        vec3.copy(this._interPoint, this._tmpInter);
+        this._pickedFace = iFacesCandidates[i];
       }
     }
-    if (this.#pickedFace !== -1) {
-      this.#mesh = mesh;
+    if (this._pickedFace !== -1) {
+      this._mesh = mesh;
       this.updateLocalAndWorldRadius2();
       return true;
     }
-    this.#rLocal2 = 0.0;
+    this._rLocal2 = 0.0;
     return false;
   }
 
   /** Find all the vertices inside the sphere */
   pickVerticesInSphere(rLocal2) {
-    var mesh = this.#mesh;
+    var mesh = this._mesh;
     var vAr = mesh.getVertices();
     var vertSculptFlags = mesh.getVerticesSculptFlags();
     var inter = this.getIntersectionPoint();
@@ -363,19 +363,19 @@ class Picking {
       }
     }
 
-    this.#pickedVertices = new Uint32Array(pickedVertices.subarray(0, acc));
-    return this.#pickedVertices;
+    this._pickedVertices = new Uint32Array(pickedVertices.subarray(0, acc));
+    return this._pickedVertices;
   }
 
   _isInsideSphere(id, inter, rLocal2) {
     if (id === Utils.TRI_INDEX) return false;
     var iv = id * 3;
-    return vec3.sqrDist(inter, this.#mesh.getVertices().subarray(iv, iv + 3)) <= rLocal2;
+    return vec3.sqrDist(inter, this._mesh.getVertices().subarray(iv, iv + 3)) <= rLocal2;
   }
 
   /** Find all the vertices inside the sphere (with topological check) */
   pickVerticesInSphereTopological(rLocal2) {
-    var mesh = this.#mesh;
+    var mesh = this._mesh;
     var nbVertices = mesh.getNbVertices();
     var vAr = mesh.getVertices();
     var fAr = mesh.getFaces();
@@ -440,45 +440,45 @@ class Picking {
       }
     }
 
-    this.#pickedVertices = new Uint32Array(pickedVertices.subarray(0, acc));
-    return this.#pickedVertices;
+    this._pickedVertices = new Uint32Array(pickedVertices.subarray(0, acc));
+    return this._pickedVertices;
   }
 
   computeWorldRadius2(ignorePressure = false) {
 
-    vec3.transformMat4(this.#tmpInter, this.getIntersectionPoint(), this.#mesh.getMatrix());
+    vec3.transformMat4(this._tmpInter, this.getIntersectionPoint(), this._mesh.getMatrix());
 
-    var offsetX = this.#main.getSculptManager().getCurrentTool().getScreenRadius();
+    var offsetX = this._main.getSculptManager().getCurrentTool().getScreenRadius();
     if (!ignorePressure) offsetX *= Tablet.getPressureRadius();
 
-    var screenInter = this.project(this.#tmpInter);
-    return vec3.sqrDist(this.#tmpInter, this.unproject(screenInter[0] + offsetX, screenInter[1], screenInter[2]));
+    var screenInter = this.project(this._tmpInter);
+    return vec3.sqrDist(this._tmpInter, this.unproject(screenInter[0] + offsetX, screenInter[1], screenInter[2]));
   }
 
   updateLocalAndWorldRadius2() {
-    if (!this.#mesh) return;
-    this.#rWorld2 = this.computeWorldRadius2();
-    this.#rLocal2 = this.#rWorld2 / this.#mesh.getScale2();
+    if (!this._mesh) return;
+    this._rWorld2 = this.computeWorldRadius2();
+    this._rLocal2 = this._rWorld2 / this._mesh.getScale2();
   }
 
   unproject(x, y, z) {
-    return this.#main.getCamera().unproject(x, y, z);
+    return this._main.getCamera().unproject(x, y, z);
   }
 
   project(vec) {
-    return this.#main.getCamera().project(vec);
+    return this._main.getCamera().project(vec);
   }
 
   computePickedNormal() {
-    if (!this.#mesh || this.#pickedFace < 0) return;
-    this.polyLerp(this.#mesh.getNormals(), this.#pickedNormal);
-    return vec3.normalize(this.#pickedNormal, this.#pickedNormal);
+    if (!this._mesh || this._pickedFace < 0) return;
+    this.polyLerp(this._mesh.getNormals(), this._pickedNormal);
+    return vec3.normalize(this._pickedNormal, this._pickedNormal);
   }
 
   polyLerp(vField, out) {
-    var vAr = this.#mesh.getVertices();
-    var fAr = this.#mesh.getFaces();
-    var id = this.#pickedFace * 4;
+    var vAr = this._mesh.getVertices();
+    var fAr = this._mesh.getFaces();
+    var id = this._pickedFace * 4;
     var iv1 = fAr[id] * 3;
     var iv2 = fAr[id + 1] * 3;
     var iv3 = fAr[id + 2] * 3;
@@ -487,10 +487,10 @@ class Picking {
     var isQuad = iv4 !== Utils.TRI_INDEX;
     if (isQuad) iv4 *= 3;
 
-    var len1 = 1.0 / vec3.dist(this.#interPoint, vAr.subarray(iv1, iv1 + 3));
-    var len2 = 1.0 / vec3.dist(this.#interPoint, vAr.subarray(iv2, iv2 + 3));
-    var len3 = 1.0 / vec3.dist(this.#interPoint, vAr.subarray(iv3, iv3 + 3));
-    var len4 = isQuad ? 1.0 / vec3.dist(this.#interPoint, vAr.subarray(iv4, iv4 + 3)) : 0.0;
+    var len1 = 1.0 / vec3.dist(this._interPoint, vAr.subarray(iv1, iv1 + 3));
+    var len2 = 1.0 / vec3.dist(this._interPoint, vAr.subarray(iv2, iv2 + 3));
+    var len3 = 1.0 / vec3.dist(this._interPoint, vAr.subarray(iv3, iv3 + 3));
+    var len4 = isQuad ? 1.0 / vec3.dist(this._interPoint, vAr.subarray(iv4, iv4 + 3)) : 0.0;
 
     var invSum = 1.0 / (len1 + len2 + len3 + len4);
     vec3.set(out, 0.0, 0.0, 0.0);


### PR DESCRIPTION
Instead of using the new #private syntax, we will use the older _prop syntax for now as a lot of the unmigrated code expects public/protected fields using _.

Later we can go back and sprinkle around protected and private once everything uses typescript